### PR TITLE
Add config file and account for windows paths

### DIFF
--- a/Rhai.toml
+++ b/Rhai.toml
@@ -1,0 +1,2 @@
+[source]
+include = ["examples/**/*.rhai"]

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -16,12 +16,14 @@ az = "1.2.0"
 clap = { version = "3.2.6", features = ["derive"] }
 figment = "0.10.6"
 futures = "0.3.21"
-ignore = "0.4.18"
+glob = "0.3.0"
+globset = "0.4.9"
 indexmap = "1.9.1"
 itertools = "0.10.3"
 lsp-async-stub = { version = "0.6.0", features = ["tokio-stdio"] }
 lsp-types = "0.93.0"
 once_cell = "1.12.0"
+percent-encoding = "2.1.0"
 rhai-hir = { version = "0.1.0", path = "../hir" }
 rhai-rowan = { version = "0.1.0", path = "../rowan" }
 serde = { version = "1.0.137", features = ["derive"] }
@@ -33,6 +35,7 @@ tokio = { version = "1.19.2", features = [
     "parking_lot",
     "macros",
     "fs",
+    "time",
 ] }
 toml = "0.5.9"
 tracing = "0.1.35"

--- a/crates/lsp/src/config.rs
+++ b/crates/lsp/src/config.rs
@@ -1,11 +1,81 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use figment::{providers::Serialized, Figment};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RhaiConfig {}
+use crate::{
+    environment::Environment,
+    utils::{GlobRule, Normalize},
+};
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct RhaiConfig {
+    pub source: RhaiSourceConfig,
+}
+
+impl RhaiConfig {
+    pub fn prepare(&mut self, e: &impl Environment, base: &Path) -> anyhow::Result<()> {
+        self.source.prepare(e, base)
+    }
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct RhaiSourceConfig {
+    /// A list of UNIX-style glob patterns
+    /// for Rhai files that should be included.
+    pub include: Option<Vec<String>>,
+    /// A list of UNIX-style glob patterns.
+    /// For Rhai files that should be excluded.
+    pub exclude: Option<Vec<String>>,
+
+    #[serde(skip)]
+    pub file_rule: Option<GlobRule>,
+}
+
+impl RhaiSourceConfig {
+    pub fn prepare(&mut self, e: &impl Environment, base: &Path) -> anyhow::Result<()> {
+        self.make_absolute(e, base);
+
+        self.include = self
+            .include
+            .take()
+            .or_else(|| Some(vec![String::from("**/*.rhai")]));
+
+        self.file_rule = Some(GlobRule::new(
+            self.include.as_deref().unwrap(),
+            self.exclude.as_deref().unwrap_or(&[] as &[String]),
+        )?);
+
+        Ok(())
+    }
+
+    fn make_absolute(&mut self, e: &impl Environment, base: &Path) {
+        if let Some(included) = &mut self.include {
+            for pat in included {
+                if !e.is_absolute(Path::new(pat)) {
+                    *pat = base
+                        .join(pat.as_str())
+                        .normalize()
+                        .to_string_lossy()
+                        .into_owned();
+                }
+            }
+        }
+
+        if let Some(excluded) = &mut self.exclude {
+            for pat in excluded {
+                if !e.is_absolute(Path::new(pat)) {
+                    *pat = base
+                        .join(pat.as_str())
+                        .normalize()
+                        .to_string_lossy()
+                        .into_owned();
+                }
+            }
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/lsp/src/diagnostics.rs
+++ b/crates/lsp/src/diagnostics.rs
@@ -9,13 +9,16 @@ use lsp_types::{
 };
 use rhai_hir::{error::ErrorKind, Hir};
 
+#[tracing::instrument(skip_all)]
 pub(crate) async fn publish_all_diagnostics<E: Environment>(context: Context<World<E>>) {
     let workspaces = context.workspaces.read().await;
-
-    for doc_url in workspaces
+    let document_urls = workspaces
         .iter()
         .flat_map(|(_, ws)| ws.documents.keys().cloned())
-    {
+        .collect::<Vec<_>>();
+    drop(workspaces);
+
+    for doc_url in document_urls {
         context
             .env
             .clone()

--- a/crates/lsp/src/environment.rs
+++ b/crates/lsp/src/environment.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::{path::{Path, PathBuf}, time::Duration};
 
 use async_trait::async_trait;
 use futures::Future;
@@ -23,5 +23,14 @@ pub trait Environment: Clone + Send + Sync + 'static {
 
     fn url_to_file_path(&self, url: &Url) -> Option<PathBuf>;
 
-    fn rhai_files(&self, root: &Path) -> Result<Vec<PathBuf>, anyhow::Error>;
+    /// Absolute current working dir.
+    fn cwd(&self) -> Option<PathBuf>;
+
+    fn glob_files(&self, glob: &str) -> Result<Vec<PathBuf>, anyhow::Error>;
+
+    fn is_absolute(&self, path: &Path) -> bool;
+
+    fn discover_rhai_config(&self, root: &Path) -> Option<PathBuf>;
+
+    async fn sleep(&self, duration: Duration);
 }

--- a/crates/lsp/src/handlers/completion.rs
+++ b/crates/lsp/src/handlers/completion.rs
@@ -1,6 +1,6 @@
 use crate::{
     environment::Environment,
-    utils::{documentation_for, signature_of},
+    utils::{documentation_for, signature_of, Normalize},
     world::World,
 };
 use itertools::Itertools;
@@ -37,7 +37,7 @@ pub(crate) async fn completion<E: Environment>(
         None => return Ok(None),
     };
 
-    let source = match ws.hir.source_of(&uri) {
+    let source = match ws.hir.source_of(&uri.clone().normalize()) {
         Some(s) => s,
         None => return Ok(None),
     };

--- a/crates/lsp/src/handlers/configuration.rs
+++ b/crates/lsp/src/handlers/configuration.rs
@@ -1,7 +1,4 @@
-use crate::{
-    environment::Environment,
-    world::{World, DEFAULT_WORKSPACE_URL},
-};
+use crate::{environment::Environment, world::World};
 use anyhow::Context as AnyhowContext;
 use lsp_async_stub::{Context, Params, RequestWriter};
 use lsp_types::{
@@ -37,8 +34,8 @@ pub async fn update_configuration<E: Environment>(context: Context<World<E>>) {
 
     let config_items: Vec<_> = workspaces
         .iter()
-        .filter_map(|(url, _)| {
-            if *url == *DEFAULT_WORKSPACE_URL {
+        .filter_map(|(url, ws)| {
+            if ws.is_detached() {
                 None
             } else {
                 Some(ConfigurationItem {
@@ -48,10 +45,6 @@ pub async fn update_configuration<E: Environment>(context: Context<World<E>>) {
             }
         })
         .collect();
-
-    for (url, _) in workspaces.iter() {
-        if *url == *DEFAULT_WORKSPACE_URL {}
-    }
 
     let res = context
         .clone()

--- a/crates/lsp/src/handlers/document_symbols.rs
+++ b/crates/lsp/src/handlers/document_symbols.rs
@@ -1,6 +1,6 @@
 #![allow(deprecated)]
 
-use crate::{environment::Environment, utils::signature_of, world::World};
+use crate::{environment::Environment, utils::{signature_of, Normalize}, world::World};
 use lsp_async_stub::{
     rpc,
     util::{LspExt, Mapper},
@@ -26,7 +26,7 @@ pub(crate) async fn document_symbols<E: Environment>(
 
     let syntax = doc.parse.clone().into_syntax();
 
-    let source = match ws.hir.source_of(&p.text_document.uri) {
+    let source = match ws.hir.source_of(&p.text_document.uri.clone().normalize()) {
         Some(s) => s,
         None => return Ok(None),
     };

--- a/crates/lsp/src/handlers/documents.rs
+++ b/crates/lsp/src/handlers/documents.rs
@@ -6,9 +6,10 @@ use lsp_types::{
 use rhai_rowan::{parser::Parser, util::is_rhai_def};
 
 use crate::{
-    diagnostics::publish_all_diagnostics,
+    diagnostics::{publish_all_diagnostics, publish_diagnostics},
     environment::Environment,
-    world::{Document, Workspaces, World},
+    utils::Normalize,
+    world::{Document, World},
 };
 
 #[tracing::instrument(skip_all)]
@@ -21,35 +22,18 @@ pub(crate) async fn document_open<E: Environment>(
         Some(p) => p,
     };
 
-    let mut workspaces = context.workspaces.write().await;
     update_document(
-        &mut *workspaces,
-        &p.text_document.uri,
+        context.clone(),
+        p.text_document.uri.clone(),
         &p.text_document.text,
-    );
+    )
+    .await;
+    publish_diagnostics(context.clone(), p.text_document.uri).await;
 
-    let ws = workspaces.by_document(&p.text_document.uri);
-
-    let mut missing_modules = ws.hir.missing_modules();
-
-    // TODO: proper strategy for loading modules.
-    let mut last_len = 0;
-
-    while missing_modules.len() > 0 {
-        if last_len == missing_modules.len() {
-            break;
-        }
-
-        last_len = missing_modules.len();
-
-        load_missing_documents(context.clone(), &mut *workspaces, missing_modules).await;
-        let ws = workspaces.by_document(&p.text_document.uri);
-        missing_modules = ws.hir.missing_modules();
-    }
-
-    load_missing_documents(context.clone(), &mut *workspaces, missing_modules).await;
-    drop(workspaces);
-    publish_all_diagnostics(context).await;
+    context
+        .clone()
+        .all_diagnostics_debouncer
+        .spawn(publish_all_diagnostics(context));
 }
 
 #[tracing::instrument(skip_all)]
@@ -68,30 +52,13 @@ pub(crate) async fn document_change<E: Environment>(
         Some(c) => c,
     };
 
-    let mut workspaces = context.workspaces.write().await;
-    update_document(&mut *workspaces, &p.text_document.uri, &change.text);
+    update_document(context.clone(), p.text_document.uri.clone(), &change.text).await;
+    publish_diagnostics(context.clone(), p.text_document.uri).await;
 
-    let ws = workspaces.by_document(&p.text_document.uri);
-
-    let mut missing_modules = ws.hir.missing_modules();
-
-    // TODO: proper strategy for loading modules.
-    let mut last_len = 0;
-
-    while missing_modules.len() > 0 {
-        if last_len == missing_modules.len() {
-            break;
-        }
-
-        last_len = missing_modules.len();
-
-        load_missing_documents(context.clone(), &mut *workspaces, missing_modules).await;
-        let ws = workspaces.by_document(&p.text_document.uri);
-        missing_modules = ws.hir.missing_modules();
-    }
-
-    drop(workspaces);
-    publish_all_diagnostics(context).await;
+    context
+        .clone()
+        .all_diagnostics_debouncer
+        .spawn(publish_all_diagnostics(context));
 }
 
 #[tracing::instrument(skip_all)]
@@ -110,57 +77,22 @@ pub(crate) async fn document_close<E: Environment>(
     // no-op, we track it until it is deleted.
 }
 
-pub(crate) fn update_document<E: Environment>(
-    workspaces: &mut Workspaces<E>,
-    uri: &Url,
-    text: &str,
-) {
+#[tracing::instrument(skip_all)]
+pub(crate) async fn update_document<E: Environment>(ctx: Context<World<E>>, uri: Url, text: &str) {
     let parse = if is_rhai_def(text) {
         Parser::new(text).parse_def()
     } else {
         Parser::new(text).parse_script()
     };
 
+    let uri = uri.normalize();
+
     let mapper = Mapper::new_utf16(text, false);
 
-    let ws = workspaces.by_document_mut(uri);
+    let mut ws = ctx.workspaces.write().await;
+    let ws = ws.by_document_mut(&uri);
 
-    ws.hir.add_source(uri, &parse.clone_syntax());
+    ws.hir.add_source(&uri, &parse.clone_syntax());
     ws.hir.resolve_references();
     ws.documents.insert(uri.clone(), Document { parse, mapper });
-}
-
-#[tracing::instrument(skip_all)]
-pub(crate) async fn load_missing_documents<E: Environment>(
-    context: Context<World<E>>,
-    workspaces: &mut Workspaces<E>,
-    urls: impl Iterator<Item = Url>,
-) {
-    for url in urls {
-        let path = match context.env.url_to_file_path(&url) {
-            Some(p) => p,
-            None => {
-                tracing::warn!(%url, "could not create file path from url");
-                continue;
-            }
-        };
-
-        let file_content = match context.env.read_file(&path).await {
-            Ok(c) => c,
-            Err(err) => {
-                tracing::error!(error = %err, "failed to read file");
-                continue;
-            }
-        };
-
-        let source = match String::from_utf8(file_content) {
-            Ok(s) => s,
-            Err(error) => {
-                tracing::error!(%url, %error, "source is not valid UTF-8");
-                continue;
-            }
-        };
-
-        update_document(workspaces, &url, &source);
-    }
 }

--- a/crates/lsp/src/handlers/goto.rs
+++ b/crates/lsp/src/handlers/goto.rs
@@ -1,4 +1,4 @@
-use crate::{environment::Environment, world::World};
+use crate::{environment::Environment, world::World, utils::Normalize};
 
 use lsp_async_stub::{rpc, util::LspExt, Context, Params};
 use lsp_types::{
@@ -54,7 +54,7 @@ async fn goto_target<E: Environment>(
         None => return Ok(None),
     };
 
-    let source = match ws.hir.source_of(&uri) {
+    let source = match ws.hir.source_of(&uri.clone().normalize()) {
         Some(s) => s,
         None => return Ok(None),
     };

--- a/crates/lsp/src/handlers/hover.rs
+++ b/crates/lsp/src/handlers/hover.rs
@@ -1,4 +1,4 @@
-use crate::{environment::Environment, utils::documentation_for, world::World};
+use crate::{environment::Environment, utils::{documentation_for, Normalize}, world::World};
 use lsp_async_stub::{rpc, util::LspExt, Context, Params};
 use lsp_types::{Hover, HoverContents, HoverParams, MarkupContent, MarkupKind, Range};
 use rhai_hir::{symbol::ReferenceTarget, Hir, Symbol};
@@ -26,7 +26,7 @@ pub(crate) async fn hover<E: Environment>(
         None => return Ok(None),
     };
 
-    let source = match ws.hir.source_of(&uri) {
+    let source = match ws.hir.source_of(&uri.clone().normalize()) {
         Some(s) => s,
         None => return Ok(None),
     };

--- a/crates/lsp/src/handlers/rename.rs
+++ b/crates/lsp/src/handlers/rename.rs
@@ -1,3 +1,4 @@
+use crate::utils::Normalize;
 use crate::world::Workspace;
 use crate::{environment::Environment, world::World};
 use core::iter;
@@ -31,7 +32,7 @@ pub async fn prepare_rename<E: Environment>(
         }
     };
 
-    let source = match ws.hir.source_of(&document_uri) {
+    let source = match ws.hir.source_of(&document_uri.clone().normalize()) {
         Some(s) => s,
         None => return Ok(None),
     };
@@ -79,7 +80,7 @@ pub async fn rename<E: Environment>(
         }
     };
 
-    let source = match ws.hir.source_of(&document_uri) {
+    let source = match ws.hir.source_of(&document_uri.clone().normalize()) {
         Some(s) => s,
         None => return Ok(None),
     };

--- a/crates/lsp/src/utils.rs
+++ b/crates/lsp/src/utils.rs
@@ -1,8 +1,25 @@
+use std::{
+    borrow::Cow,
+    mem,
+    path::{Path, PathBuf},
+    time::Duration, sync::Arc,
+};
+
+use arc_swap::ArcSwapOption;
+use futures::{
+    future::{AbortHandle, Abortable},
+    Future,
+};
+use globset::{Glob, GlobSetBuilder};
+use lsp_types::Url;
+use percent_encoding::percent_decode_str;
 use rhai_hir::{Hir, Symbol, Type};
 use rhai_rowan::{
     ast::{AstNode, ExprFn},
     syntax::{SyntaxElement, SyntaxNode},
 };
+
+use crate::environment::Environment;
 
 /// Format signatures and definitions of symbols.
 pub fn signature_of(hir: &Hir, root: &SyntaxNode, symbol: Symbol) -> String {
@@ -95,5 +112,135 @@ pub trait RhaiStringExt {
 impl<T: AsRef<str>> RhaiStringExt for T {
     fn wrap_rhai_markdown(&self) -> String {
         format!("```rhai\n{}\n```", self.as_ref().trim_end())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GlobRule {
+    include: globset::GlobSet,
+    exclude: globset::GlobSet,
+}
+
+impl GlobRule {
+    pub fn new(
+        include: impl IntoIterator<Item = impl AsRef<str>>,
+        exclude: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Result<Self, anyhow::Error> {
+        let mut inc = GlobSetBuilder::new();
+        for glob in include {
+            inc.add(Glob::new(glob.as_ref())?);
+        }
+
+        let mut exc = GlobSetBuilder::new();
+        for glob in exclude {
+            exc.add(Glob::new(glob.as_ref())?);
+        }
+
+        Ok(Self {
+            include: inc.build()?,
+            exclude: exc.build()?,
+        })
+    }
+
+    pub fn is_match(&self, text: impl AsRef<Path>) -> bool {
+        if !self.include.is_match(text.as_ref()) {
+            return false;
+        }
+
+        !self.exclude.is_match(text.as_ref())
+    }
+}
+
+pub trait Normalize {
+    /// Normalizing in the context of this library means the following:
+    ///
+    /// - replace `\` with `/` on windows
+    /// - decode all percent-encoded characters
+    #[must_use]
+    fn normalize(self) -> Self;
+}
+
+impl Normalize for PathBuf {
+    fn normalize(self) -> Self {
+        match self.to_str() {
+            Some(s) => (*normalize_str(s)).into(),
+            None => self,
+        }
+    }
+}
+
+impl Normalize for Vec<PathBuf> {
+    fn normalize(mut self) -> Self {
+        for p in &mut self {
+            *p = mem::take(p).normalize();
+        }
+        self
+    }
+}
+
+impl Normalize for Url {
+    fn normalize(self) -> Self {
+        if self.scheme() != "file" {
+            return self;
+        }
+
+        if let Ok(u) = normalize_str(self.as_str()).parse() {
+            return u;
+        }
+
+        self
+    }
+}
+
+pub(crate) fn normalize_str(s: &str) -> Cow<str> {
+    let percent_decoded = match percent_decode_str(s).decode_utf8().ok() {
+        Some(s) => s,
+        None => return s.into(),
+    };
+
+    if cfg!(windows) {
+        percent_decoded.replace('\\', "/").into()
+    } else {
+        percent_decoded
+    }
+}
+
+pub struct Debouncer<E: Environment> {
+    duration: Duration,
+    handle: ArcSwapOption<AbortHandle>,
+    env: E,
+}
+
+impl<E: Environment> Debouncer<E> {
+    pub fn new(duration: Duration, env: E) -> Self {
+        Self {
+            duration,
+            handle: Default::default(),
+            env,
+        }
+    }
+
+    pub fn spawn(&self, fut: impl Future + 'static) {
+        let prev_handle = self.handle.swap(None);
+
+        if let Some(handle) = prev_handle {
+            handle.abort();
+        }
+
+        let (abort_handle, abort_reg) = AbortHandle::new_pair();
+
+        let duration = self.duration;
+        let env = self.env.clone();
+
+        let fut = Abortable::new(
+            async move {
+                env.sleep(duration).await;
+                fut.await;
+            },
+            abort_reg,
+        );
+
+        self.handle.store(Some(Arc::new(abort_handle)));
+        self.env.spawn_local(fut);
     }
 }

--- a/crates/lsp/src/world.rs
+++ b/crates/lsp/src/world.rs
@@ -1,16 +1,21 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use crate::{
-    config::{InitConfig, LspConfig},
+    config::{InitConfig, LspConfig, RhaiConfig},
     environment::Environment,
+    utils::{Debouncer, Normalize},
     IndexMap,
 };
+use anyhow::anyhow;
 use arc_swap::ArcSwap;
 use lsp_async_stub::{rpc, util::Mapper};
 use lsp_types::Url;
 use once_cell::sync::Lazy;
 use rhai_hir::Hir;
-use rhai_rowan::parser::Parse;
+use rhai_rowan::{
+    parser::{Parse, Parser},
+    util::is_rhai_def,
+};
 use tokio::sync::RwLock as AsyncRwLock;
 
 pub static DEFAULT_WORKSPACE_URL: Lazy<Url> = Lazy::new(|| Url::parse("root:///").unwrap());
@@ -21,6 +26,7 @@ pub struct WorldState<E: Environment> {
     pub(crate) init_config: ArcSwap<InitConfig>,
     pub(crate) env: E,
     pub(crate) workspaces: AsyncRwLock<Workspaces<E>>,
+    pub(crate) all_diagnostics_debouncer: Debouncer<E>,
 }
 
 impl<E: Environment> WorldState<E> {
@@ -29,17 +35,12 @@ impl<E: Environment> WorldState<E> {
 
         ws.insert(
             DEFAULT_WORKSPACE_URL.clone(),
-            Workspace {
-                env: env.clone(),
-                root: DEFAULT_WORKSPACE_URL.clone(),
-                config: LspConfig::default(),
-                documents: Default::default(),
-                hir: Default::default(),
-            },
+            Workspace::new(env.clone(), DEFAULT_WORKSPACE_URL.clone()),
         );
 
         Self {
             init_config: Default::default(),
+            all_diagnostics_debouncer: Debouncer::new(Duration::from_secs(1), env.clone()),
             env,
             workspaces: AsyncRwLock::new(ws),
         }
@@ -103,6 +104,7 @@ impl<E: Environment> Workspaces<E> {
 pub struct Workspace<E: Environment> {
     pub(crate) env: E,
     pub(crate) config: LspConfig,
+    pub(crate) rhai_config: RhaiConfig,
     pub(crate) root: Url,
     pub(crate) documents: IndexMap<lsp_types::Url, Document>,
     pub(crate) hir: Hir,
@@ -110,9 +112,11 @@ pub struct Workspace<E: Environment> {
 
 impl<E: Environment> Workspace<E> {
     pub(crate) fn new(env: E, root: Url) -> Self {
+        tracing::info!(%root, "created workspace");
         Self {
             env,
             root,
+            rhai_config: Default::default(),
             config: LspConfig::default(),
             documents: Default::default(),
             hir: Default::default(),
@@ -125,6 +129,119 @@ impl<E: Environment> Workspace<E> {
         self.documents
             .get(url)
             .ok_or_else(rpc::Error::invalid_params)
+    }
+
+    pub(crate) fn is_detached(&self) -> bool {
+        self.root == *DEFAULT_WORKSPACE_URL
+    }
+
+    pub(crate) async fn load_rhai_config(&mut self) -> anyhow::Result<()> {
+        self.rhai_config = Default::default();
+
+        let root_path = match self.env.url_to_file_path(&self.root) {
+            Some(p) => p.normalize(),
+            None => return Err(anyhow!("workspace root is not a valid file path")),
+        };
+
+        if let Some(config_path) = self.env.discover_rhai_config(&root_path) {
+            tracing::info!(path = ?config_path, "found Rhai.toml");
+            match self
+                .env
+                .read_file(&config_path.normalize())
+                .await
+                .and_then(|v| toml::from_slice(&v).map_err(Into::into))
+            {
+                Ok(c) => self.rhai_config = c,
+                Err(error) => {
+                    tracing::error!(%error, "failed to read configuration");
+                }
+            }
+        } else {
+            tracing::debug!("no config file found");
+        }
+
+        self.rhai_config.prepare(&self.env, &root_path)
+    }
+
+    pub(crate) async fn load_all_files(&mut self) {
+        let includes = self.rhai_config.source.include.as_ref().unwrap();
+
+        let mut paths = Vec::new();
+
+        let workspace_root = match self.env.url_to_file_path(&self.root) {
+            Some(root) => root.normalize(),
+            None => {
+                tracing::debug!("workspace is not in a valid filesystem");
+                return;
+            }
+        };
+
+        for include_pattern in includes {
+            let pattern_paths = match self
+                .env
+                .glob_files(&workspace_root.join(include_pattern).to_string_lossy())
+            {
+                Ok(paths) => paths.normalize(),
+                Err(error) => {
+                    tracing::error!(%error, "failed to load files");
+                    continue;
+                }
+            };
+
+            paths.extend(pattern_paths);
+        }
+
+        paths.dedup();
+
+        let all = paths.len();
+
+        if let Some(rule) = &self.rhai_config.source.file_rule {
+            paths.retain(|p| rule.is_match(p));
+        }
+
+        let excluded = all - paths.len();
+
+        tracing::info!(count = all, excluded, "found files");
+
+        for path in paths {
+            tracing::debug!(?path, "found file");
+
+            let document_url = Url::parse(&format!("file://{}", path.to_string_lossy())).unwrap();
+
+            let source = match self.env.read_file(&path).await {
+                Ok(src) => src,
+                Err(error) => {
+                    tracing::error!(%error, "failed to read file");
+                    continue;
+                }
+            };
+
+            let source_text = match String::from_utf8(source) {
+                Ok(s) => s,
+                Err(error) => {
+                    tracing::error!(%error, "given source is not valid UTF-8");
+                    continue;
+                }
+            };
+
+            self.add_document(document_url, &source_text);
+        }
+    }
+
+    pub fn add_document(&mut self, url: Url, text: &str) {
+        let parse = if is_rhai_def(text) {
+            Parser::new(text).parse_def()
+        } else {
+            Parser::new(text).parse_script()
+        };
+
+        let mapper = Mapper::new_utf16(text, false);
+
+        let url = url.normalize();
+
+        self.hir.add_source(&url, &parse.clone_syntax());
+        self.hir.resolve_references();
+        self.documents.insert(url, Document { parse, mapper });
     }
 }
 

--- a/crates/lsp/src/world.rs
+++ b/crates/lsp/src/world.rs
@@ -70,7 +70,12 @@ impl<E: Environment> Workspaces<E> {
     pub fn by_document(&self, url: &Url) -> &Workspace<E> {
         self.0
             .iter()
-            .filter(|(key, _)| url.as_str().starts_with(key.as_str()))
+            .filter(|(key, _)| {
+                let normalized_url = (*key).clone().normalize();
+
+                url.as_str().starts_with(key.as_str())
+                    || url.as_str().starts_with(normalized_url.as_str())
+            })
             .max_by(|(a, _), (b, _)| a.as_str().len().cmp(&b.as_str().len()))
             .map_or_else(
                 || {
@@ -86,7 +91,11 @@ impl<E: Environment> Workspaces<E> {
         self.0
             .iter_mut()
             .filter(|(key, _)| {
-                url.as_str().starts_with(key.as_str()) || *key == &*DEFAULT_WORKSPACE_URL
+                let normalized_url = (*key).clone().normalize();
+
+                url.as_str().starts_with(key.as_str())
+                    || url.as_str().starts_with(normalized_url.as_str())
+                    || *key == &*DEFAULT_WORKSPACE_URL
             })
             .max_by(|(a, _), (b, _)| a.as_str().len().cmp(&b.as_str().len()))
             .map(|(k, ws)| {

--- a/crates/lsp/src/world.rs
+++ b/crates/lsp/src/world.rs
@@ -246,9 +246,9 @@ impl<E: Environment> Workspace<E> {
 
         let mapper = Mapper::new_utf16(text, false);
 
-        let url = url.normalize();
+        let normalized_url = url.clone().normalize();
 
-        self.hir.add_source(&url, &parse.clone_syntax());
+        self.hir.add_source(&normalized_url, &parse.clone_syntax());
         self.hir.resolve_references();
         self.documents.insert(url, Document { parse, mapper });
     }

--- a/crates/lsp/src/world.rs
+++ b/crates/lsp/src/world.rs
@@ -137,6 +137,7 @@ impl<E: Environment> Workspace<E> {
     pub(crate) fn document(&self, url: &Url) -> Result<&Document, rpc::Error> {
         self.documents
             .get(url)
+            .or_else(|| self.documents.get(&url.clone().normalize()))
             .ok_or_else(rpc::Error::invalid_params)
     }
 


### PR DESCRIPTION
I introduced the term to `normalize` paths and urls, which means pretty much replacing `\` with `/` and decoding percent-encoded characters. This is a one-way operation, since I have no idea how the language clients encode the urls and I don't want to care about it if possible.

Handling normalized and client-style urls added quite a bit of complexity since we have to use both of them.

We walk the fs to find and load source code according to glob patterns defined in the config file, however these paths of the rhai files are naturally not percent encoded.

All document uris we receive from the language client are percent encoded, but in most cases they happen to have been already processed by the procedure above, so the safest thing to do is to normalize all urls received by the language client and only store them in the hir that way. Obviously when we forget to do this, things will silently break due to documents being duplicated with the wrong uri or won't be found at all, fun stuff.

Other than this, we also cannot get rid of the encoded uris, because we send requests from the server-side that invloves document uris (such as diagnostics), and we have to make sure that the language client will find the document we are referring to, and the safest way to do is to use the uris as they were sent by the client (although just as I'm writing this, I've just realized that this is not possible for documents that we process ourselves, and right now it seems to work, so at least vscode is not sensitive to percent encoding and this requirement might be unnecessary).

Other than this I implemented processing of a simple `Rhai.toml` in the workspace root, and also overhauled a bit the way document loading is done.

Closes #60 and closes #39.