### PR TITLE
Module rework

### DIFF
--- a/crates/hir/src/hir.rs
+++ b/crates/hir/src/hir.rs
@@ -1,8 +1,8 @@
 mod add;
+mod errors;
 mod query;
 mod remove;
 mod resolve;
-mod errors;
 
 use core::ops;
 
@@ -139,7 +139,13 @@ impl ops::Index<Symbol> for Hir {
     type Output = SymbolData;
 
     fn index(&self, index: Symbol) -> &Self::Output {
-        self.symbols.get(index).unwrap()
+        let sym = self.symbols.get(index).unwrap();
+
+        if let SymbolKind::Virtual(VirtualSymbol::Proxy(proxy)) = &sym.kind {
+            return self.symbols.get(proxy.target).unwrap();
+        }
+
+        sym
     }
 }
 

--- a/crates/hir/src/hir/add/def.rs
+++ b/crates/hir/src/hir/add/def.rs
@@ -55,6 +55,7 @@ impl Hir {
 
         let module = self.ensure_module(module_kind);
         self.module_mut(module).docs = docs;
+        self.module_mut(module).sources.insert(source);
 
         self.source_mut(source).module = module;
 

--- a/crates/hir/src/hir/add/script.rs
+++ b/crates/hir/src/hir/add/script.rs
@@ -12,6 +12,8 @@ impl Hir {
         let url = self[source].url.clone();
 
         let module = self.ensure_module(ModuleKind::Url(url));
+        self.module_mut(module).sources.insert(source);
+
         self.source_mut(source).module = module;
 
         self.add_statements(source, self[module].scope, true, rhai.statements());

--- a/crates/hir/src/hir/query.rs
+++ b/crates/hir/src/hir/query.rs
@@ -1,8 +1,8 @@
+use crate::scope::ScopeParent;
 use core::iter;
-use std::cmp::Ordering;
 use itertools::Either;
 use rhai_rowan::{TextRange, TextSize};
-use crate::scope::ScopeParent;
+use std::cmp::Ordering;
 
 use super::*;
 
@@ -548,10 +548,14 @@ fn collect_symbol_scope_iters<'h>(
                 collect_symbol_scope_iters(hir, iters, sym);
             }
         }
+        SymbolKind::Virtual(VirtualSymbol::Module(m)) => {
+            iters.push(Box::new(hir.scope_symbols(hir[m.module].scope)));
+        }
         SymbolKind::Op(_)
         | SymbolKind::Lit(_)
         | SymbolKind::Reference(_)
         | SymbolKind::Continue(_)
-        | SymbolKind::Discard(_) => {}
+        | SymbolKind::Discard(_)
+        | SymbolKind::Virtual(VirtualSymbol::Proxy(..)) => {}
     }
 }

--- a/crates/hir/src/module.rs
+++ b/crates/hir/src/module.rs
@@ -1,4 +1,4 @@
-use crate::Scope;
+use crate::{Scope, source::Source, IndexSet};
 use url::Url;
 
 slotmap::new_key_type! { pub struct Module; }
@@ -21,6 +21,10 @@ pub struct ModuleData {
     pub scope: Scope,
     pub kind: ModuleKind,
     pub docs: String,
+    /// Protected modules must not be removed,
+    /// even if it has no sources associated.
+    pub protected: bool,
+    pub sources: IndexSet<Source>,
 }
 
 impl ModuleData {


### PR DESCRIPTION
Removed the hack of parsing an import statement for injecting a module.

Instead we can use "virtual" symbols to inject modules in arbitrary scopes, this will help with injecting the `global` module into functions as well.