### PR TITLE
String templates

### DIFF
--- a/crates/hir/src/hir/query/scope_iter.rs
+++ b/crates/hir/src/hir/query/scope_iter.rs
@@ -345,8 +345,12 @@ fn collect_symbol_scope_iters<'h>(
         SymbolKind::Virtual(VirtualSymbol::Module(m)) => {
             iters.push(Box::new(hir.scope_symbols(hir[m.module].scope)));
         }
+        SymbolKind::Lit(lit) => {
+            for scope in lit.interpolated_scopes.iter().copied() {
+                iters.push(Box::new(hir.scope_symbols(scope)));
+            }
+        }
         SymbolKind::Op(_)
-        | SymbolKind::Lit(_)
         | SymbolKind::Reference(_)
         | SymbolKind::Continue(_)
         | SymbolKind::Discard(_)

--- a/crates/hir/src/hir/remove.rs
+++ b/crates/hir/src/hir/remove.rs
@@ -237,7 +237,12 @@ impl Hir {
                     self.remove_symbol(s);
                 }
             }
-            SymbolKind::Lit(_) | SymbolKind::Continue(_) | SymbolKind::Discard(_) => {}
+            SymbolKind::Lit(lit) => {
+                for scope in lit.interpolated_scopes {
+                    self.remove_scope(scope);
+                }
+            }
+             SymbolKind::Continue(_) | SymbolKind::Discard(_) => {}
             SymbolKind::Export(e) => {
                 if let Some(s) = e.target {
                     self.remove_symbol(s);

--- a/crates/hir/src/symbol.rs
+++ b/crates/hir/src/symbol.rs
@@ -264,6 +264,15 @@ impl SymbolKind {
         }
     }
 
+    #[must_use]
+    pub fn as_lit_mut(&mut self) -> Option<&mut LitSymbol> {
+        if let Self::Lit(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
     /// Returns `true` if the symbol kind is [`Unary`].
     ///
     /// [`Unary`]: SymbolKind::Unary
@@ -713,6 +722,7 @@ pub struct PathSymbol {
 pub struct LitSymbol {
     pub ty: Type,
     pub value: Value,
+    pub interpolated_scopes: Vec<Scope>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/lsp/src/handlers/semantic_tokens.rs
+++ b/crates/lsp/src/handlers/semantic_tokens.rs
@@ -124,7 +124,7 @@ impl<'b> SemanticTokensBuilder<'b> {
             tokens.push(SemanticToken {
                 delta_line: relative.start.line as u32,
                 delta_start: relative.start.character as u32,
-                length: (relative.end.character - relative.start.character) as u32,
+                length: (relative.end.character.saturating_sub(relative.start.character)) as u32,
                 token_type: ty as u32,
                 token_modifiers_bitset: modifiers.iter().enumerate().fold(
                     0,

--- a/crates/rowan/src/ast/ext.rs
+++ b/crates/rowan/src/ast/ext.rs
@@ -6,7 +6,8 @@
 use rowan::NodeOrToken;
 
 use super::{
-    AstNode, Expr, ObjectField, Param, ParamList, SwitchArm, SwitchArmCondition, TypedParam, DefOpPrecedence,
+    AstNode, DefOpPrecedence, Expr, LitStrTemplate, LitStrTemplateInterpolation, ObjectField,
+    Param, ParamList, Stmt, SwitchArm, SwitchArmCondition, TypedParam,
 };
 use super::{ExprBlock, ExprIf, T};
 use crate::syntax::{SyntaxElement, SyntaxKind, SyntaxToken};
@@ -30,6 +31,32 @@ impl super::Rhai {
         }
 
         s
+    }
+}
+
+impl super::Lit {
+    pub fn lit_token(&self) -> Option<SyntaxToken> {
+        self.syntax()
+            .first_child_or_token()
+            .and_then(NodeOrToken::into_token)
+    }
+
+    pub fn lit_str_template(&self) -> Option<LitStrTemplate> {
+        self.syntax().first_child().and_then(LitStrTemplate::cast)
+    }
+}
+
+impl super::LitStrTemplate {
+    pub fn interpolations(&self) -> impl Iterator<Item = LitStrTemplateInterpolation> {
+        self.syntax()
+            .children()
+            .filter_map(LitStrTemplateInterpolation::cast)
+    }
+}
+
+impl super::LitStrTemplateInterpolation {
+    pub fn statements(&self) -> impl Iterator<Item = Stmt> {
+        self.syntax().children().filter_map(Stmt::cast)
     }
 }
 

--- a/crates/rowan/src/ast/mod.rs
+++ b/crates/rowan/src/ast/mod.rs
@@ -6,3 +6,4 @@ pub use generated::*;
 
 mod ext;
 pub use ext::*;
+ 

--- a/crates/rowan/src/ast/rhai.ungram
+++ b/crates/rowan/src/ast/rhai.ungram
@@ -1,13 +1,3 @@
-Lit =
-  'lit_int'
-| 'lit_float'
-| 'lit_str'
-| 'lit_bool'
-| 'lit_char'
-
-Path =
-  root:'ident' segments:('::' 'ident')*
-
 // Some Rhai code, could be a file, a module, etc.
 Rhai =
   'shebang'?
@@ -60,8 +50,26 @@ ExprIdent =
 ExprPath =
   Path
 
+
+Path =
+  root:'ident' segments:('::' 'ident')*
+
+LitStrTemplate =
+  ('lit_str' '${' LitStrTemplateInterpolation '}')* 'lit_str'
+
+LitStrTemplateInterpolation =
+  statements:Stmt*
+
 ExprLit =
   Lit
+
+Lit =
+  'lit_int'
+| 'lit_float'
+| 'lit_str'
+| 'lit_bool'
+| 'lit_char'
+| LitStrTemplate
 
 ExprLet =
   'let' 'ident' assignment:('=' Expr)?

--- a/crates/rowan/src/parser/context.rs
+++ b/crates/rowan/src/parser/context.rs
@@ -200,11 +200,32 @@ impl<'src> Context<'src> {
         self.statement_closed = v;
     }
 
+    /// Bump the slice of the current token by `n` bytes.
+    pub fn bump(&mut self, n: usize) {
+        self.lexer.bump(n);
+    }
+
+    #[must_use]
+    pub fn remainder(&self) -> &str {
+        self.lexer.remainder()
+    }
+
     #[must_use]
     pub fn slice(&self) -> &str {
         self.ambiguous_tokens
             .as_ref()
             .map_or_else(|| self.lexer.slice(), AmbiguousTokens::slice)
+    }
+
+    /// Get the next token from the inner lexer without
+    /// any magic such as whitespace or error handling.
+    /// 
+    /// This token is also not cached, so the existing token
+    /// will always be overwritten.
+    #[must_use]
+    pub fn token_raw(&mut self) -> Option<SyntaxKind> {
+        self.current_token = self.lexer.next();
+        self.current_token
     }
 
     #[must_use]

--- a/crates/rowan/src/parser/mod.rs
+++ b/crates/rowan/src/parser/mod.rs
@@ -159,6 +159,9 @@ pub enum ParseErrorKind {
     #[error(r#"unexpected token"#)]
     UnexpectedToken,
 
+    #[error(r#"invalid or unclosed string"#)]
+    InvalidOrUnclosedString,
+
     #[error(r#"expected token "{0:?}""#)]
     ExpectedToken(SyntaxKind),
 

--- a/crates/rowan/tests/smoke.rs
+++ b/crates/rowan/tests/smoke.rs
@@ -1,5 +1,5 @@
 use rhai_rowan::{
-    parser::{Operator, Parser, parsers::parse_expr},
+    parser::{parsers::parse_expr, Operator, Parser},
     syntax::SyntaxKind::*,
 };
 use test_case::test_case;
@@ -34,8 +34,12 @@ use test_case::test_case;
 #[test_case("throw_try_catch", include_str!("../../../testdata/valid/throw_try_catch.rhai"))]
 #[test_case("optional_ops", include_str!("../../../testdata/valid/optional_ops.rhai"))]
 #[test_case("string_escape", include_str!("../../../testdata/valid/string_escape.rhai"))]
+#[test_case("template", include_str!("../../../testdata/valid/template.rhai"))]
 fn parse_valid(name: &str, src: &str) {
-    let parse = Parser::new(src).parse_script();
+    let parse = Parser::new(src)
+        // This operator does not actually exist among the scripts.
+        .with_operator("op", Operator::default())
+        .parse_script();
     assert!(parse.errors.is_empty(), "{:#?}", parse.errors);
 
     let mut engine = rhai::Engine::new();
@@ -113,7 +117,6 @@ fn parse_ambiguous_ranges() {
         ctx.eat();
     });
 }
-
 
 #[test]
 fn parse_ambiguous_integer_field_access() {

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@array.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@array.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 37
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..109
@@ -111,7 +111,25 @@ RHAI@0..109
             EXPR@79..106
               EXPR_LIT@79..106
                 LIT@79..106
-                  LIT_STR@79..106 "`x[1] should be 5: ${ ..."
+                  LIT_STR_TEMPLATE@79..106
+                    LIT_STR@79..98 "`x[1] should be 5: "
+                    INTERPOLATION_START@98..100 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@100..104
+                      STMT@100..104
+                        ITEM@100..104
+                          EXPR@100..104
+                            EXPR_INDEX@100..104
+                              EXPR@100..101
+                                EXPR_IDENT@100..101
+                                  IDENT@100..101 "x"
+                              PUNCT_BRACKET_START@101..102 "["
+                              EXPR@102..103
+                                EXPR_LIT@102..103
+                                  LIT@102..103
+                                    LIT_INT@102..103 "1"
+                              PUNCT_BRACKET_END@103..104 "]"
+                    PUNCT_BRACE_END@104..105 "}"
+                    LIT_STR@105..106 "`"
             PUNCT_PAREN_END@106..107 ")"
     PUNCT_SEMI@107..108 ";"
   WHITESPACE@108..109 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@assignment.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@assignment.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 37
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..100
@@ -34,7 +34,17 @@ RHAI@0..100
             EXPR@75..97
               EXPR_LIT@75..97
                 LIT@75..97
-                  LIT_STR@75..97 "`x should be 78: ${x}`"
+                  LIT_STR_TEMPLATE@75..97
+                    LIT_STR@75..92 "`x should be 78: "
+                    INTERPOLATION_START@92..94 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@94..95
+                      STMT@94..95
+                        ITEM@94..95
+                          EXPR@94..95
+                            EXPR_IDENT@94..95
+                              IDENT@94..95 "x"
+                    PUNCT_BRACE_END@95..96 "}"
+                    LIT_STR@96..97 "`"
             PUNCT_PAREN_END@97..98 ")"
     PUNCT_SEMI@98..99 ";"
   WHITESPACE@99..100 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@fibonacci.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@fibonacci.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 37
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..635
@@ -167,7 +167,26 @@ RHAI@0..635
             EXPR@284..335
               EXPR_LIT@284..335
                 LIT@284..335
-                  LIT_STR@284..335 "`Running Fibonacci(${ ..."
+                  LIT_STR_TEMPLATE@284..335
+                    LIT_STR@284..303 "`Running Fibonacci("
+                    INTERPOLATION_START@303..305 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@305..311
+                      STMT@305..311
+                        ITEM@305..311
+                          EXPR@305..311
+                            EXPR_IDENT@305..311
+                              IDENT@305..311 "TARGET"
+                    PUNCT_BRACE_END@311..312 "}"
+                    LIT_STR@312..316 ") x "
+                    INTERPOLATION_START@316..318 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@318..324
+                      STMT@318..324
+                        ITEM@318..324
+                          EXPR@318..324
+                            EXPR_IDENT@318..324
+                              IDENT@318..324 "REPEAT"
+                    PUNCT_BRACE_END@324..325 "}"
+                    LIT_STR@325..335 " times...`"
             PUNCT_PAREN_END@335..336 ")"
     PUNCT_SEMI@336..337 ";"
   WHITESPACE@337..338 "\n"
@@ -279,7 +298,23 @@ RHAI@0..635
             EXPR@454..500
               EXPR_LIT@454..500
                 LIT@454..500
-                  LIT_STR@454..500 "`Finished. Run time = ..."
+                  LIT_STR_TEMPLATE@454..500
+                    LIT_STR@454..476 "`Finished. Run time = "
+                    INTERPOLATION_START@476..478 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@478..489
+                      STMT@478..489
+                        ITEM@478..489
+                          EXPR@478..489
+                            EXPR_BINARY@478..489
+                              EXPR@478..481
+                                EXPR_IDENT@478..481
+                                  IDENT@478..481 "now"
+                              PUNCT_DOT@481..482 "."
+                              EXPR@482..489
+                                EXPR_IDENT@482..489
+                                  IDENT@482..489 "elapsed"
+                    PUNCT_BRACE_END@489..490 "}"
+                    LIT_STR@490..500 " seconds.`"
             PUNCT_PAREN_END@500..501 ")"
     PUNCT_SEMI@501..502 ";"
   WHITESPACE@502..504 "\n\n"
@@ -295,7 +330,26 @@ RHAI@0..635
             EXPR@510..551
               EXPR_LIT@510..551
                 LIT@510..551
-                  LIT_STR@510..551 "`Fibonacci number #${ ..."
+                  LIT_STR_TEMPLATE@510..551
+                    LIT_STR@510..529 "`Fibonacci number #"
+                    INTERPOLATION_START@529..531 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@531..537
+                      STMT@531..537
+                        ITEM@531..537
+                          EXPR@531..537
+                            EXPR_IDENT@531..537
+                              IDENT@531..537 "TARGET"
+                    PUNCT_BRACE_END@537..538 "}"
+                    LIT_STR@538..541 " = "
+                    INTERPOLATION_START@541..543 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@543..549
+                      STMT@543..549
+                        ITEM@543..549
+                          EXPR@543..549
+                            EXPR_IDENT@543..549
+                              IDENT@543..549 "result"
+                    PUNCT_BRACE_END@549..550 "}"
+                    LIT_STR@550..551 "`"
             PUNCT_PAREN_END@551..552 ")"
     PUNCT_SEMI@552..553 ";"
   WHITESPACE@553..555 "\n\n"
@@ -332,7 +386,17 @@ RHAI@0..635
                       EXPR@587..630
                         EXPR_LIT@587..630
                           LIT@587..630
-                            LIT_STR@587..630 "`The answer is WRONG! ..."
+                            LIT_STR_TEMPLATE@587..630
+                              LIT_STR@587..619 "`The answer is WRONG! ..."
+                              INTERPOLATION_START@619..621 "${"
+                              LIT_STR_TEMPLATE_INTERPOLATION@621..627
+                                STMT@621..627
+                                  ITEM@621..627
+                                    EXPR@621..627
+                                      EXPR_IDENT@621..627
+                                        IDENT@621..627 "ANSWER"
+                              PUNCT_BRACE_END@627..628 "}"
+                              LIT_STR@628..630 "!`"
                       PUNCT_PAREN_END@630..631 ")"
               PUNCT_SEMI@631..632 ";"
             WHITESPACE@632..633 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@for1.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@for1.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 37
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..523
@@ -188,7 +188,44 @@ RHAI@0..523
                                 EXPR@227..256
                                   EXPR_LIT@227..256
                                     LIT@227..256
-                                      LIT_STR@227..256 "`(${i}, ${j}) = (${a} ..."
+                                      LIT_STR_TEMPLATE@227..256
+                                        LIT_STR@227..229 "`("
+                                        INTERPOLATION_START@229..231 "${"
+                                        LIT_STR_TEMPLATE_INTERPOLATION@231..232
+                                          STMT@231..232
+                                            ITEM@231..232
+                                              EXPR@231..232
+                                                EXPR_IDENT@231..232
+                                                  IDENT@231..232 "i"
+                                        PUNCT_BRACE_END@232..233 "}"
+                                        LIT_STR@233..235 ", "
+                                        INTERPOLATION_START@235..237 "${"
+                                        LIT_STR_TEMPLATE_INTERPOLATION@237..238
+                                          STMT@237..238
+                                            ITEM@237..238
+                                              EXPR@237..238
+                                                EXPR_IDENT@237..238
+                                                  IDENT@237..238 "j"
+                                        PUNCT_BRACE_END@238..239 "}"
+                                        LIT_STR@239..244 ") = ("
+                                        INTERPOLATION_START@244..246 "${"
+                                        LIT_STR_TEMPLATE_INTERPOLATION@246..247
+                                          STMT@246..247
+                                            ITEM@246..247
+                                              EXPR@246..247
+                                                EXPR_IDENT@246..247
+                                                  IDENT@246..247 "a"
+                                        PUNCT_BRACE_END@247..248 "}"
+                                        LIT_STR@248..250 ", "
+                                        INTERPOLATION_START@250..252 "${"
+                                        LIT_STR_TEMPLATE_INTERPOLATION@252..253
+                                          STMT@252..253
+                                            ITEM@252..253
+                                              EXPR@252..253
+                                                EXPR_IDENT@252..253
+                                                  IDENT@252..253 "b"
+                                        PUNCT_BRACE_END@253..254 "}"
+                                        LIT_STR@254..256 ")`"
                                 PUNCT_PAREN_END@256..257 ")"
                         PUNCT_SEMI@257..258 ";"
                       WHITESPACE@258..263 "\n    "

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@for2.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@for2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 61
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..422
@@ -34,7 +34,17 @@ RHAI@0..422
             EXPR@61..102
               EXPR_LIT@61..102
                 LIT@61..102
-                  LIT_STR@61..102 "`Iterating an array w ..."
+                  LIT_STR_TEMPLATE@61..102
+                    LIT_STR@61..86 "`Iterating an array w ..."
+                    INTERPOLATION_START@86..88 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@88..91
+                      STMT@88..91
+                        ITEM@88..91
+                          EXPR@88..91
+                            EXPR_IDENT@88..91
+                              IDENT@88..91 "MAX"
+                    PUNCT_BRACE_END@91..92 "}"
+                    LIT_STR@92..102 " items...`"
             PUNCT_PAREN_END@102..103 ")"
     PUNCT_SEMI@103..104 ";"
   WHITESPACE@104..106 "\n\n"
@@ -153,7 +163,23 @@ RHAI@0..422
             EXPR@234..268
               EXPR_LIT@234..268
                 LIT@234..268
-                  LIT_STR@234..268 "`Time = ${now.elapsed ..."
+                  LIT_STR_TEMPLATE@234..268
+                    LIT_STR@234..242 "`Time = "
+                    INTERPOLATION_START@242..244 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@244..255
+                      STMT@244..255
+                        ITEM@244..255
+                          EXPR@244..255
+                            EXPR_BINARY@244..255
+                              EXPR@244..247
+                                EXPR_IDENT@244..247
+                                  IDENT@244..247 "now"
+                              PUNCT_DOT@247..248 "."
+                              EXPR@248..255
+                                EXPR_IDENT@248..255
+                                  IDENT@248..255 "elapsed"
+                    PUNCT_BRACE_END@255..256 "}"
+                    LIT_STR@256..268 " seconds...`"
             PUNCT_PAREN_END@268..269 ")"
     PUNCT_SEMI@269..270 ";"
   WHITESPACE@270..272 "\n\n"
@@ -223,7 +249,17 @@ RHAI@0..422
             EXPR@344..358
               EXPR_LIT@344..358
                 LIT@344..358
-                  LIT_STR@344..358 "`Sum = ${sum}`"
+                  LIT_STR_TEMPLATE@344..358
+                    LIT_STR@344..351 "`Sum = "
+                    INTERPOLATION_START@351..353 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@353..356
+                      STMT@353..356
+                        ITEM@353..356
+                          EXPR@353..356
+                            EXPR_IDENT@353..356
+                              IDENT@353..356 "sum"
+                    PUNCT_BRACE_END@356..357 "}"
+                    LIT_STR@357..358 "`"
             PUNCT_PAREN_END@358..359 ")"
     PUNCT_SEMI@359..360 ";"
   WHITESPACE@360..361 "\n"
@@ -239,7 +275,23 @@ RHAI@0..422
             EXPR@367..419
               EXPR_LIT@367..419
                 LIT@367..419
-                  LIT_STR@367..419 "`Finished. Total run  ..."
+                  LIT_STR_TEMPLATE@367..419
+                    LIT_STR@367..395 "`Finished. Total run  ..."
+                    INTERPOLATION_START@395..397 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@397..408
+                      STMT@397..408
+                        ITEM@397..408
+                          EXPR@397..408
+                            EXPR_BINARY@397..408
+                              EXPR@397..400
+                                EXPR_IDENT@397..400
+                                  IDENT@397..400 "now"
+                              PUNCT_DOT@400..401 "."
+                              EXPR@401..408
+                                EXPR_IDENT@401..408
+                                  IDENT@401..408 "elapsed"
+                    PUNCT_BRACE_END@408..409 "}"
+                    LIT_STR@409..419 " seconds.`"
             PUNCT_PAREN_END@419..420 ")"
     PUNCT_SEMI@420..421 ";"
   WHITESPACE@421..422 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@function_decl1.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@function_decl1.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 37
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..149
@@ -66,7 +66,17 @@ RHAI@0..149
             EXPR@112..146
               EXPR_LIT@112..146
                 LIT@112..146
-                  LIT_STR@112..146 "`call_me() should be  ..."
+                  LIT_STR_TEMPLATE@112..146
+                    LIT_STR@112..136 "`call_me() should be 3: "
+                    INTERPOLATION_START@136..138 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@138..144
+                      STMT@138..144
+                        ITEM@138..144
+                          EXPR@138..144
+                            EXPR_IDENT@138..144
+                              IDENT@138..144 "result"
+                    PUNCT_BRACE_END@144..145 "}"
+                    LIT_STR@145..146 "`"
             PUNCT_PAREN_END@146..147 ")"
     PUNCT_SEMI@147..148 ";"
   WHITESPACE@148..149 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@function_decl2.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@function_decl2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 37
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..412
@@ -120,7 +120,17 @@ RHAI@0..412
             EXPR@299..334
               EXPR_LIT@299..334
                 LIT@299..334
-                  LIT_STR@299..334 "`add(a, 4) should be  ..."
+                  LIT_STR_TEMPLATE@299..334
+                    LIT_STR@299..324 "`add(a, 4) should be  ..."
+                    INTERPOLATION_START@324..326 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@326..332
+                      STMT@326..332
+                        ITEM@326..332
+                          EXPR@326..332
+                            EXPR_IDENT@326..332
+                              IDENT@326..332 "result"
+                    PUNCT_BRACE_END@332..333 "}"
+                    LIT_STR@333..334 "`"
             PUNCT_PAREN_END@334..335 ")"
     PUNCT_SEMI@335..336 ";"
   WHITESPACE@336..338 "\n\n"
@@ -136,7 +146,17 @@ RHAI@0..412
             EXPR@344..371
               EXPR_LIT@344..371
                 LIT@344..371
-                  LIT_STR@344..371 "`a should still be 3: ..."
+                  LIT_STR_TEMPLATE@344..371
+                    LIT_STR@344..366 "`a should still be 3: "
+                    INTERPOLATION_START@366..368 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@368..369
+                      STMT@368..369
+                        ITEM@368..369
+                          EXPR@368..369
+                            EXPR_IDENT@368..369
+                              IDENT@368..369 "a"
+                    PUNCT_BRACE_END@369..370 "}"
+                    LIT_STR@370..371 "`"
             PUNCT_PAREN_END@371..372 ")"
     PUNCT_SEMI@372..373 ";"
   WHITESPACE@373..378 "     "

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@function_decl3.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@function_decl3.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 37
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..274
@@ -202,7 +202,17 @@ RHAI@0..274
             EXPR@239..271
               EXPR_LIT@239..271
                 LIT@239..271
-                  LIT_STR@239..271 "`result should be 42: ..."
+                  LIT_STR_TEMPLATE@239..271
+                    LIT_STR@239..261 "`result should be 42: "
+                    INTERPOLATION_START@261..263 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@263..269
+                      STMT@263..269
+                        ITEM@263..269
+                          EXPR@263..269
+                            EXPR_IDENT@263..269
+                              IDENT@263..269 "result"
+                    PUNCT_BRACE_END@269..270 "}"
+                    LIT_STR@270..271 "`"
             PUNCT_PAREN_END@271..272 ")"
     PUNCT_SEMI@272..273 ";"
   WHITESPACE@273..274 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@function_decl4.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@function_decl4.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 61
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..314
@@ -135,7 +135,17 @@ RHAI@0..314
             EXPR@281..311
               EXPR_LIT@281..311
                 LIT@281..311
-                  LIT_STR@281..311 "`obj should now be 42 ..."
+                  LIT_STR_TEMPLATE@281..311
+                    LIT_STR@281..304 "`obj should now be 42: "
+                    INTERPOLATION_START@304..306 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@306..309
+                      STMT@306..309
+                        ITEM@306..309
+                          EXPR@306..309
+                            EXPR_IDENT@306..309
+                              IDENT@306..309 "obj"
+                    PUNCT_BRACE_END@309..310 "}"
+                    LIT_STR@310..311 "`"
             PUNCT_PAREN_END@311..312 ")"
     PUNCT_SEMI@312..313 ";"
   WHITESPACE@313..314 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@if2.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@if2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 37
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..183
@@ -128,7 +128,17 @@ RHAI@0..183
             EXPR@157..180
               EXPR_LIT@157..180
                 LIT@157..180
-                  LIT_STR@157..180 "`x should be 810: ${x}`"
+                  LIT_STR_TEMPLATE@157..180
+                    LIT_STR@157..175 "`x should be 810: "
+                    INTERPOLATION_START@175..177 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@177..178
+                      STMT@177..178
+                        ITEM@177..178
+                          EXPR@177..178
+                            EXPR_IDENT@177..178
+                              IDENT@177..178 "x"
+                    PUNCT_BRACE_END@178..179 "}"
+                    LIT_STR@179..180 "`"
             PUNCT_PAREN_END@180..181 ")"
     PUNCT_SEMI@181..182 ";"
   WHITESPACE@182..183 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@mat_mul.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@mat_mul.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 61
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..1027
@@ -932,7 +932,23 @@ RHAI@0..1027
             EXPR@978..1024
               EXPR_LIT@978..1024
                 LIT@978..1024
-                  LIT_STR@978..1024 "`Finished. Run time = ..."
+                  LIT_STR_TEMPLATE@978..1024
+                    LIT_STR@978..1000 "`Finished. Run time = "
+                    INTERPOLATION_START@1000..1002 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@1002..1013
+                      STMT@1002..1013
+                        ITEM@1002..1013
+                          EXPR@1002..1013
+                            EXPR_BINARY@1002..1013
+                              EXPR@1002..1005
+                                EXPR_IDENT@1002..1005
+                                  IDENT@1002..1005 "now"
+                              PUNCT_DOT@1005..1006 "."
+                              EXPR@1006..1013
+                                EXPR_IDENT@1006..1013
+                                  IDENT@1006..1013 "elapsed"
+                    PUNCT_BRACE_END@1013..1014 "}"
+                    LIT_STR@1014..1024 " seconds.`"
             PUNCT_PAREN_END@1024..1025 ")"
     PUNCT_SEMI@1025..1026 ";"
   WHITESPACE@1026..1027 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@module.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@module.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 37
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..116
@@ -34,7 +34,20 @@ RHAI@0..116
             EXPR@83..113
               EXPR_LIT@83..113
                 LIT@83..113
-                  LIT_STR@83..113 "`Module test! foo = $ ..."
+                  LIT_STR_TEMPLATE@83..113
+                    LIT_STR@83..103 "`Module test! foo = "
+                    INTERPOLATION_START@103..105 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@105..111
+                      STMT@105..111
+                        ITEM@105..111
+                          EXPR@105..111
+                            EXPR_PATH@105..111
+                              PATH@105..111
+                                IDENT@105..106 "x"
+                                PUNCT_COLON2@106..108 "::"
+                                IDENT@108..111 "foo"
+                    PUNCT_BRACE_END@111..112 "}"
+                    LIT_STR@112..113 "`"
             PUNCT_PAREN_END@113..114 ")"
     PUNCT_SEMI@114..115 ";"
   WHITESPACE@115..116 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@oop.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@oop.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 61
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..1409
@@ -95,7 +95,23 @@ RHAI@0..1409
                           EXPR@334..354
                             EXPR_LIT@334..354
                               LIT@334..354
-                                LIT_STR@334..354 "`Data=${this._data}`"
+                                LIT_STR_TEMPLATE@334..354
+                                  LIT_STR@334..340 "`Data="
+                                  INTERPOLATION_START@340..342 "${"
+                                  LIT_STR_TEMPLATE_INTERPOLATION@342..352
+                                    STMT@342..352
+                                      ITEM@342..352
+                                        EXPR@342..352
+                                          EXPR_BINARY@342..352
+                                            EXPR@342..346
+                                              EXPR_IDENT@342..346
+                                                IDENT@342..346 "this"
+                                            PUNCT_DOT@346..347 "."
+                                            EXPR@347..352
+                                              EXPR_IDENT@347..352
+                                                IDENT@347..352 "_data"
+                                  PUNCT_BRACE_END@352..353 "}"
+                                  LIT_STR@353..354 "`"
                           PUNCT_PAREN_END@354..355 ")"
               PUNCT_COMMA@355..356 ","
               WHITESPACE@356..361 "     "
@@ -511,7 +527,17 @@ RHAI@0..1409
             EXPR@1377..1406
               EXPR_LIT@1377..1406
                 LIT@1377..1406
-                  LIT_STR@1377..1406 "`Should be 84: ${last ..."
+                  LIT_STR_TEMPLATE@1377..1406
+                    LIT_STR@1377..1392 "`Should be 84: "
+                    INTERPOLATION_START@1392..1394 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@1394..1404
+                      STMT@1394..1404
+                        ITEM@1394..1404
+                          EXPR@1394..1404
+                            EXPR_IDENT@1394..1404
+                              IDENT@1394..1404 "last_value"
+                    PUNCT_BRACE_END@1404..1405 "}"
+                    LIT_STR@1405..1406 "`"
             PUNCT_PAREN_END@1406..1407 ")"
     PUNCT_SEMI@1407..1408 ";"
   WHITESPACE@1408..1409 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@primes.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@primes.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 61
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..734
@@ -330,7 +330,26 @@ RHAI@0..734
             EXPR@534..596
               EXPR_LIT@534..596
                 LIT@534..596
-                  LIT_STR@534..596 "`Total ${total_primes ..."
+                  LIT_STR_TEMPLATE@534..596
+                    LIT_STR@534..541 "`Total "
+                    INTERPOLATION_START@541..543 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@543..561
+                      STMT@543..561
+                        ITEM@543..561
+                          EXPR@543..561
+                            EXPR_IDENT@543..561
+                              IDENT@543..561 "total_primes_found"
+                    PUNCT_BRACE_END@561..562 "}"
+                    LIT_STR@562..573 " primes <= "
+                    INTERPOLATION_START@573..575 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@575..594
+                      STMT@575..594
+                        ITEM@575..594
+                          EXPR@575..594
+                            EXPR_IDENT@575..594
+                              IDENT@575..594 "MAX_NUMBER_TO_CHECK"
+                    PUNCT_BRACE_END@594..595 "}"
+                    LIT_STR@595..596 "`"
             PUNCT_PAREN_END@596..597 ")"
     PUNCT_SEMI@597..598 ";"
   WHITESPACE@598..599 "\n"
@@ -346,7 +365,23 @@ RHAI@0..734
             EXPR@605..641
               EXPR_LIT@605..641
                 LIT@605..641
-                  LIT_STR@605..641 "`Run time = ${now.ela ..."
+                  LIT_STR_TEMPLATE@605..641
+                    LIT_STR@605..617 "`Run time = "
+                    INTERPOLATION_START@617..619 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@619..630
+                      STMT@619..630
+                        ITEM@619..630
+                          EXPR@619..630
+                            EXPR_BINARY@619..630
+                              EXPR@619..622
+                                EXPR_IDENT@619..622
+                                  IDENT@619..622 "now"
+                              PUNCT_DOT@622..623 "."
+                              EXPR@623..630
+                                EXPR_IDENT@623..630
+                                  IDENT@623..630 "elapsed"
+                    PUNCT_BRACE_END@630..631 "}"
+                    LIT_STR@631..641 " seconds.`"
             PUNCT_PAREN_END@641..642 ")"
     PUNCT_SEMI@642..643 ";"
   WHITESPACE@643..645 "\n\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@speed_test.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@speed_test.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 37
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..236
@@ -110,7 +110,23 @@ RHAI@0..236
             EXPR@187..233
               EXPR_LIT@187..233
                 LIT@187..233
-                  LIT_STR@187..233 "`Finished. Run time = ..."
+                  LIT_STR_TEMPLATE@187..233
+                    LIT_STR@187..209 "`Finished. Run time = "
+                    INTERPOLATION_START@209..211 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@211..222
+                      STMT@211..222
+                        ITEM@211..222
+                          EXPR@211..222
+                            EXPR_BINARY@211..222
+                              EXPR@211..214
+                                EXPR_IDENT@211..214
+                                  IDENT@211..214 "now"
+                              PUNCT_DOT@214..215 "."
+                              EXPR@215..222
+                                EXPR_IDENT@215..222
+                                  IDENT@215..222 "elapsed"
+                    PUNCT_BRACE_END@222..223 "}"
+                    LIT_STR@223..233 " seconds.`"
             PUNCT_PAREN_END@233..234 ")"
     PUNCT_SEMI@234..235 ";"
   WHITESPACE@235..236 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@string.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@string.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 37
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..1385
@@ -241,7 +241,23 @@ RHAI@0..1385
             EXPR@596..613
               EXPR_LIT@596..613
                 LIT@596..613
-                  LIT_STR@596..613 "`length=${s.len}`"
+                  LIT_STR_TEMPLATE@596..613
+                    LIT_STR@596..604 "`length="
+                    INTERPOLATION_START@604..606 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@606..611
+                      STMT@606..611
+                        ITEM@606..611
+                          EXPR@606..611
+                            EXPR_BINARY@606..611
+                              EXPR@606..607
+                                EXPR_IDENT@606..607
+                                  IDENT@606..607 "s"
+                              PUNCT_DOT@607..608 "."
+                              EXPR@608..611
+                                EXPR_IDENT@608..611
+                                  IDENT@608..611 "len"
+                    PUNCT_BRACE_END@611..612 "}"
+                    LIT_STR@612..613 "`"
             PUNCT_PAREN_END@613..614 ")"
     PUNCT_SEMI@614..615 ";"
   WHITESPACE@615..622 "       "
@@ -297,7 +313,17 @@ RHAI@0..1385
             EXPR@698..714
               EXPR_LIT@698..714
                 LIT@698..714
-                  LIT_STR@698..714 "`Question: ${s}`"
+                  LIT_STR_TEMPLATE@698..714
+                    LIT_STR@698..709 "`Question: "
+                    INTERPOLATION_START@709..711 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@711..712
+                      STMT@711..712
+                        ITEM@711..712
+                          EXPR@711..712
+                            EXPR_IDENT@711..712
+                              IDENT@711..712 "s"
+                    PUNCT_BRACE_END@712..713 "}"
+                    LIT_STR@713..714 "`"
             PUNCT_PAREN_END@714..715 ")"
     PUNCT_SEMI@715..716 ";"
   WHITESPACE@716..724 "        "
@@ -335,7 +361,17 @@ RHAI@0..1385
             EXPR@911..929
               EXPR_LIT@911..929
                 LIT@911..929
-                  LIT_STR@911..929 "`One string: ${s}`"
+                  LIT_STR_TEMPLATE@911..929
+                    LIT_STR@911..924 "`One string: "
+                    INTERPOLATION_START@924..926 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@926..927
+                      STMT@926..927
+                        ITEM@926..927
+                          EXPR@926..927
+                            EXPR_IDENT@926..927
+                              IDENT@926..927 "s"
+                    PUNCT_BRACE_END@927..928 "}"
+                    LIT_STR@928..929 "`"
             PUNCT_PAREN_END@929..930 ")"
     PUNCT_SEMI@930..931 ";"
   WHITESPACE@931..933 "\n\n"
@@ -354,7 +390,8 @@ RHAI@0..1385
             WHITESPACE@970..971 " "
             EXPR_LIT@971..1108
               LIT@971..1108
-                LIT_STR@971..1108 "`\n          \\U0001F60 ..."
+                LIT_STR_TEMPLATE@971..1108
+                  LIT_STR@971..1108 "`\n          \\U0001F60 ..."
     PUNCT_SEMI@1108..1109 ";"
   WHITESPACE@1109..1111 "\n\n"
   STMT@1111..1120
@@ -387,7 +424,61 @@ RHAI@0..1385
             WHITESPACE@1146..1147 " "
             EXPR_LIT@1147..1349
               LIT@1147..1349
-                LIT_STR@1147..1349 "`This is interpolatio ..."
+                LIT_STR_TEMPLATE@1147..1349
+                  LIT_STR@1147..1170 "`This is interpolation "
+                  INTERPOLATION_START@1170..1172 "${"
+                  LIT_STR_TEMPLATE_INTERPOLATION@1172..1324
+                    WHITESPACE@1172..1185 "\n            "
+                    STMT@1185..1309
+                      ITEM@1185..1308
+                        EXPR@1185..1308
+                          EXPR_LET@1185..1308
+                            KW_LET@1185..1188 "let"
+                            WHITESPACE@1188..1189 " "
+                            IDENT@1189..1190 "x"
+                            WHITESPACE@1190..1191 " "
+                            OP_ASSIGN@1191..1192 "="
+                            EXPR@1192..1308
+                              WHITESPACE@1192..1193 " "
+                              EXPR_LIT@1193..1308
+                                LIT@1193..1308
+                                  LIT_STR_TEMPLATE@1193..1308
+                                    LIT_STR@1193..1201 "`within "
+                                    INTERPOLATION_START@1201..1203 "${"
+                                    LIT_STR_TEMPLATE_INTERPOLATION@1203..1292
+                                      STMT@1203..1290
+                                        ITEM@1203..1289
+                                          EXPR@1203..1289
+                                            EXPR_LET@1203..1289
+                                              KW_LET@1203..1206 "let"
+                                              WHITESPACE@1206..1207 " "
+                                              IDENT@1207..1208 "y"
+                                              WHITESPACE@1208..1209 " "
+                                              OP_ASSIGN@1209..1210 "="
+                                              EXPR@1210..1289
+                                                WHITESPACE@1210..1211 " "
+                                                EXPR_LIT@1211..1289
+                                                  LIT@1211..1289
+                                                    LIT_STR@1211..1289 "\"yet another level \\\n ..."
+                                        PUNCT_SEMI@1289..1290 ";"
+                                      WHITESPACE@1290..1291 " "
+                                      STMT@1291..1292
+                                        ITEM@1291..1292
+                                          EXPR@1291..1292
+                                            EXPR_IDENT@1291..1292
+                                              IDENT@1291..1292 "y"
+                                    PUNCT_BRACE_END@1292..1293 "}"
+                                    LIT_STR@1293..1308 " interpolation`"
+                      PUNCT_SEMI@1308..1309 ";"
+                    WHITESPACE@1309..1322 "\n            "
+                    STMT@1322..1324
+                      ITEM@1322..1324
+                        EXPR@1322..1324
+                          EXPR_IDENT@1322..1324
+                            IDENT@1322..1323 "x"
+                            WHITESPACE@1323..1324 "\n"
+                  PUNCT_BRACE_END@1324..1325 "}"
+                  LIT_STR@1325..1349 " within literal string.`"
     PUNCT_SEMI@1349..1350 ";"
   WHITESPACE@1350..1352 "\n\n"
   STMT@1352..1361

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@string_escape.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@string_escape.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 58
+assertion_line: 62
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..62
@@ -49,7 +49,8 @@ RHAI@0..62
             WHITESPACE@38..39 " "
             EXPR_LIT@39..43
               LIT@39..43
-                LIT_STR@39..43 "````"
+                LIT_STR_TEMPLATE@39..43
+                  LIT_STR@39..43 "````"
     PUNCT_SEMI@43..44 ";"
   WHITESPACE@44..45 "\n"
   STMT@45..60
@@ -65,7 +66,8 @@ RHAI@0..62
             WHITESPACE@52..53 " "
             EXPR_LIT@53..59
               LIT@53..59
-                LIT_STR@53..59 "` `` `"
+                LIT_STR_TEMPLATE@53..59
+                  LIT_STR@53..59 "` `` `"
     PUNCT_SEMI@59..60 ";"
   WHITESPACE@60..62 "\n\n"
 

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@strings_map.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@strings_map.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 61
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..5234
@@ -2605,7 +2605,35 @@ RHAI@0..5234
                                               EXPR@4924..4958
                                                 EXPR_LIT@4924..4958
                                                   LIT@4924..4958
-                                                    LIT_STR@4924..4958 "`${adverb} ${adjectiv ..."
+                                                    LIT_STR_TEMPLATE@4924..4958
+                                                      LIT_STR@4924..4925 "`"
+                                                      INTERPOLATION_START@4925..4927 "${"
+                                                      LIT_STR_TEMPLATE_INTERPOLATION@4927..4933
+                                                        STMT@4927..4933
+                                                          ITEM@4927..4933
+                                                            EXPR@4927..4933
+                                                              EXPR_IDENT@4927..4933
+                                                                IDENT@4927..4933 "adverb"
+                                                      PUNCT_BRACE_END@4933..4934 "}"
+                                                      LIT_STR@4934..4935 " "
+                                                      INTERPOLATION_START@4935..4937 "${"
+                                                      LIT_STR_TEMPLATE_INTERPOLATION@4937..4946
+                                                        STMT@4937..4946
+                                                          ITEM@4937..4946
+                                                            EXPR@4937..4946
+                                                              EXPR_IDENT@4937..4946
+                                                                IDENT@4937..4946 "adjective"
+                                                      PUNCT_BRACE_END@4946..4947 "}"
+                                                      LIT_STR@4947..4948 " "
+                                                      INTERPOLATION_START@4948..4950 "${"
+                                                      LIT_STR_TEMPLATE_INTERPOLATION@4950..4956
+                                                        STMT@4950..4956
+                                                          ITEM@4950..4956
+                                                            EXPR@4950..4956
+                                                              EXPR_IDENT@4950..4956
+                                                                IDENT@4950..4956 "animal"
+                                                      PUNCT_BRACE_END@4956..4957 "}"
+                                                      LIT_STR@4957..4958 "`"
                                               PUNCT_PAREN_END@4958..4959 ")"
                                           WHITESPACE@4959..4968 "\n        "
                                 PUNCT_BRACE_END@4968..4969 "}"
@@ -2818,7 +2846,17 @@ RHAI@0..5234
             EXPR@5162..5176
               EXPR_LIT@5162..5176
                 LIT@5162..5176
-                  LIT_STR@5162..5176 "`Sum = ${sum}`"
+                  LIT_STR_TEMPLATE@5162..5176
+                    LIT_STR@5162..5169 "`Sum = "
+                    INTERPOLATION_START@5169..5171 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@5171..5174
+                      STMT@5171..5174
+                        ITEM@5171..5174
+                          EXPR@5171..5174
+                            EXPR_IDENT@5171..5174
+                              IDENT@5171..5174 "sum"
+                    PUNCT_BRACE_END@5174..5175 "}"
+                    LIT_STR@5175..5176 "`"
             PUNCT_PAREN_END@5176..5177 ")"
     PUNCT_SEMI@5177..5178 ";"
   WHITESPACE@5178..5179 "\n"
@@ -2834,7 +2872,23 @@ RHAI@0..5234
             EXPR@5185..5231
               EXPR_LIT@5185..5231
                 LIT@5185..5231
-                  LIT_STR@5185..5231 "`Finished. Run time = ..."
+                  LIT_STR_TEMPLATE@5185..5231
+                    LIT_STR@5185..5207 "`Finished. Run time = "
+                    INTERPOLATION_START@5207..5209 "${"
+                    LIT_STR_TEMPLATE_INTERPOLATION@5209..5220
+                      STMT@5209..5220
+                        ITEM@5209..5220
+                          EXPR@5209..5220
+                            EXPR_BINARY@5209..5220
+                              EXPR@5209..5212
+                                EXPR_IDENT@5209..5212
+                                  IDENT@5209..5212 "now"
+                              PUNCT_DOT@5212..5213 "."
+                              EXPR@5213..5220
+                                EXPR_IDENT@5213..5220
+                                  IDENT@5213..5220 "elapsed"
+                    PUNCT_BRACE_END@5220..5221 "}"
+                    LIT_STR@5221..5231 " seconds.`"
             PUNCT_PAREN_END@5231..5232 ")"
     PUNCT_SEMI@5232..5233 ";"
   WHITESPACE@5233..5234 "\n"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@switch.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@switch.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rowan/tests/smoke.rs
-assertion_line: 60
+assertion_line: 65
 expression: "format!(\"{:#?}\", parse.into_syntax())"
 ---
 RHAI@0..779
@@ -162,7 +162,17 @@ RHAI@0..779
                               EXPR@300..327
                                 EXPR_LIT@300..327
                                   LIT@300..327
-                                    LIT_STR@300..327 "`Floating point... ${ ..."
+                                    LIT_STR_TEMPLATE@300..327
+                                      LIT_STR@300..319 "`Floating point... "
+                                      INTERPOLATION_START@319..321 "${"
+                                      LIT_STR_TEMPLATE_INTERPOLATION@321..325
+                                        STMT@321..325
+                                          ITEM@321..325
+                                            EXPR@321..325
+                                              EXPR_IDENT@321..325
+                                                IDENT@321..325 "item"
+                                      PUNCT_BRACE_END@325..326 "}"
+                                      LIT_STR@326..327 "`"
                               PUNCT_PAREN_END@327..328 ")"
                       PUNCT_COMMA@328..329 ","
                       WHITESPACE@329..338 "\n        "
@@ -186,7 +196,17 @@ RHAI@0..779
                               EXPR@386..402
                                 EXPR_LIT@386..402
                                   LIT@386..402
-                                    LIT_STR@386..402 "`${item} world!`"
+                                    LIT_STR_TEMPLATE@386..402
+                                      LIT_STR@386..387 "`"
+                                      INTERPOLATION_START@387..389 "${"
+                                      LIT_STR_TEMPLATE_INTERPOLATION@389..393
+                                        STMT@389..393
+                                          ITEM@389..393
+                                            EXPR@389..393
+                                              EXPR_IDENT@389..393
+                                                IDENT@389..393 "item"
+                                      PUNCT_BRACE_END@393..394 "}"
+                                      LIT_STR@394..402 " world!`"
                               PUNCT_PAREN_END@402..403 ")"
                       PUNCT_COMMA@403..404 ","
                       WHITESPACE@404..413 "\n        "
@@ -210,7 +230,17 @@ RHAI@0..779
                               EXPR@459..477
                                 EXPR_LIT@459..477
                                   LIT@459..477
-                                    LIT_STR@459..477 "`Got 999: ${item}`"
+                                    LIT_STR_TEMPLATE@459..477
+                                      LIT_STR@459..469 "`Got 999: "
+                                      INTERPOLATION_START@469..471 "${"
+                                      LIT_STR_TEMPLATE_INTERPOLATION@471..475
+                                        STMT@471..475
+                                          ITEM@471..475
+                                            EXPR@471..475
+                                              EXPR_IDENT@471..475
+                                                IDENT@471..475 "item"
+                                      PUNCT_BRACE_END@475..476 "}"
+                                      LIT_STR@476..477 "`"
                               PUNCT_PAREN_END@477..478 ")"
                       PUNCT_COMMA@478..479 ","
                       WHITESPACE@479..488 "\n        "
@@ -266,7 +296,17 @@ RHAI@0..779
                               EXPR@559..589
                                 EXPR_LIT@559..589
                                   LIT@559..589
-                                    LIT_STR@559..589 "`A small even number: ..."
+                                    LIT_STR_TEMPLATE@559..589
+                                      LIT_STR@559..581 "`A small even number: "
+                                      INTERPOLATION_START@581..583 "${"
+                                      LIT_STR_TEMPLATE_INTERPOLATION@583..587
+                                        STMT@583..587
+                                          ITEM@583..587
+                                            EXPR@583..587
+                                              EXPR_IDENT@583..587
+                                                IDENT@583..587 "item"
+                                      PUNCT_BRACE_END@587..588 "}"
+                                      LIT_STR@588..589 "`"
                               PUNCT_PAREN_END@589..590 ")"
                       PUNCT_COMMA@590..591 ","
                       WHITESPACE@591..600 "\n        "
@@ -297,7 +337,17 @@ RHAI@0..779
                               EXPR@647..676
                                 EXPR_LIT@647..676
                                   LIT@647..676
-                                    LIT_STR@647..676 "`A small odd number:  ..."
+                                    LIT_STR_TEMPLATE@647..676
+                                      LIT_STR@647..668 "`A small odd number: "
+                                      INTERPOLATION_START@668..670 "${"
+                                      LIT_STR_TEMPLATE_INTERPOLATION@670..674
+                                        STMT@670..674
+                                          ITEM@670..674
+                                            EXPR@670..674
+                                              EXPR_IDENT@670..674
+                                                IDENT@670..674 "item"
+                                      PUNCT_BRACE_END@674..675 "}"
+                                      LIT_STR@675..676 "`"
                               PUNCT_PAREN_END@676..677 ")"
                       PUNCT_COMMA@677..678 ","
                       WHITESPACE@678..687 "\n        "
@@ -318,7 +368,34 @@ RHAI@0..779
                               EXPR@722..769
                                 EXPR_LIT@722..769
                                   LIT@722..769
-                                    LIT_STR@722..769 "`Something else: <${i ..."
+                                    LIT_STR_TEMPLATE@722..769
+                                      LIT_STR@722..740 "`Something else: <"
+                                      INTERPOLATION_START@740..742 "${"
+                                      LIT_STR_TEMPLATE_INTERPOLATION@742..746
+                                        STMT@742..746
+                                          ITEM@742..746
+                                            EXPR@742..746
+                                              EXPR_IDENT@742..746
+                                                IDENT@742..746 "item"
+                                      PUNCT_BRACE_END@746..747 "}"
+                                      LIT_STR@747..752 "> is "
+                                      INTERPOLATION_START@752..754 "${"
+                                      LIT_STR_TEMPLATE_INTERPOLATION@754..767
+                                        STMT@754..767
+                                          ITEM@754..767
+                                            EXPR@754..767
+                                              EXPR_CALL@754..767
+                                                EXPR@754..761
+                                                  EXPR_IDENT@754..761
+                                                    IDENT@754..761 "type_of"
+                                                ARG_LIST@761..767
+                                                  PUNCT_PAREN_START@761..762 "("
+                                                  EXPR@762..766
+                                                    EXPR_IDENT@762..766
+                                                      IDENT@762..766 "item"
+                                                  PUNCT_PAREN_END@766..767 ")"
+                                      PUNCT_BRACE_END@767..768 "}"
+                                      LIT_STR@768..769 "`"
                               PUNCT_PAREN_END@769..770 ")"
                           WHITESPACE@770..775 "\n    "
                       PUNCT_BRACE_END@775..776 "}"

--- a/crates/rowan/tests/snapshots/smoke__parse_valid@template.snap
+++ b/crates/rowan/tests/snapshots/smoke__parse_valid@template.snap
@@ -1,0 +1,316 @@
+---
+source: crates/rowan/tests/smoke.rs
+assertion_line: 65
+expression: "format!(\"{:#?}\", parse.into_syntax())"
+---
+RHAI@0..386
+  STMT@0..11
+    ITEM@0..10
+      EXPR@0..10
+        EXPR_LET@0..10
+          KW_LET@0..3 "let"
+          WHITESPACE@3..4 " "
+          IDENT@4..6 "hi"
+          WHITESPACE@6..7 " "
+          OP_ASSIGN@7..8 "="
+          EXPR@8..10
+            WHITESPACE@8..9 " "
+            EXPR_LIT@9..10
+              LIT@9..10
+                LIT_INT@9..10 "2"
+    PUNCT_SEMI@10..11 ";"
+  WHITESPACE@11..12 "\n"
+  STMT@12..61
+    ITEM@12..60
+      EXPR@12..60
+        EXPR_LIT@12..60
+          LIT@12..60
+            LIT_STR_TEMPLATE@12..60
+              LIT_STR@12..13 "`"
+              INTERPOLATION_START@13..15 "${"
+              LIT_STR_TEMPLATE_INTERPOLATION@15..16
+                STMT@15..16
+                  ITEM@15..16
+                    EXPR@15..16
+                      EXPR_LIT@15..16
+                        LIT@15..16
+                          LIT_INT@15..16 "2"
+              PUNCT_BRACE_END@16..17 "}"
+              LIT_STR@17..37 "💩  💩   asd abc"
+              INTERPOLATION_START@37..39 "${"
+              LIT_STR_TEMPLATE_INTERPOLATION@39..58
+                STMT@39..58
+                  ITEM@39..58
+                    EXPR@39..58
+                      EXPR_BINARY@39..58
+                        EXPR@39..49
+                          EXPR_BINARY@39..49
+                            EXPR@39..45
+                              EXPR_BINARY@39..45
+                                EXPR@39..41
+                                  EXPR_LIT@39..40
+                                    LIT@39..40
+                                      LIT_INT@39..40 "3"
+                                  WHITESPACE@40..41 " "
+                                OP_ADD@41..42 "+"
+                                EXPR@42..45
+                                  WHITESPACE@42..43 " "
+                                  EXPR_LIT@43..44
+                                    LIT@43..44
+                                      LIT_INT@43..44 "2"
+                                  WHITESPACE@44..45 " "
+                            OP_ADD@45..46 "+"
+                            EXPR@46..49
+                              WHITESPACE@46..47 " "
+                              EXPR_LIT@47..48
+                                LIT@47..48
+                                  LIT_INT@47..48 "1"
+                              WHITESPACE@48..49 " "
+                        OP_ADD@49..50 "+"
+                        EXPR@50..58
+                          WHITESPACE@50..51 " "
+                          EXPR_LIT@51..58
+                            LIT@51..58
+                              LIT_STR_TEMPLATE@51..58
+                                LIT_STR@51..52 "`"
+                                INTERPOLATION_START@52..54 "${"
+                                LIT_STR_TEMPLATE_INTERPOLATION@54..56
+                                  STMT@54..56
+                                    ITEM@54..56
+                                      EXPR@54..56
+                                        EXPR_LIT@54..56
+                                          LIT@54..56
+                                            LIT_STR@54..56 "\"\""
+                                PUNCT_BRACE_END@56..57 "}"
+                                LIT_STR@57..58 "`"
+              PUNCT_BRACE_END@58..59 "}"
+              LIT_STR@59..60 "`"
+    PUNCT_SEMI@60..61 ";"
+  WHITESPACE@61..63 "\n\n"
+  STMT@63..100
+    ITEM@63..99
+      EXPR@63..99
+        EXPR_LET@63..99
+          KW_LET@63..66 "let"
+          WHITESPACE@66..67 " "
+          IDENT@67..68 "a"
+          WHITESPACE@68..69 " "
+          OP_ASSIGN@69..70 "="
+          EXPR@70..99
+            WHITESPACE@70..71 " "
+            EXPR_LIT@71..99
+              LIT@71..99
+                LIT_STR_TEMPLATE@71..99
+                  LIT_STR@71..92 "`with \\interpolation "
+                  INTERPOLATION_START@92..94 "${"
+                  LIT_STR_TEMPLATE_INTERPOLATION@94..96
+                    STMT@94..96
+                      ITEM@94..96
+                        EXPR@94..96
+                          EXPR_IDENT@94..96
+                            IDENT@94..96 "hi"
+                  PUNCT_BRACE_END@96..97 "}"
+                  LIT_STR@97..99 " `"
+    PUNCT_SEMI@99..100 ";"
+  WHITESPACE@100..101 "\n"
+  STMT@101..117
+    ITEM@101..116
+      EXPR@101..116
+        EXPR_LET@101..116
+          KW_LET@101..104 "let"
+          WHITESPACE@104..105 " "
+          IDENT@105..106 "a"
+          WHITESPACE@106..107 " "
+          OP_ASSIGN@107..108 "="
+          EXPR@108..116
+            WHITESPACE@108..109 " "
+            EXPR_LIT@109..116
+              LIT@109..116
+                LIT_STR_TEMPLATE@109..116
+                  LIT_STR@109..110 "`"
+                  INTERPOLATION_START@110..112 "${"
+                  LIT_STR_TEMPLATE_INTERPOLATION@112..114
+                    STMT@112..114
+                      ITEM@112..114
+                        EXPR@112..114
+                          EXPR_IDENT@112..114
+                            IDENT@112..114 "hi"
+                  PUNCT_BRACE_END@114..115 "}"
+                  LIT_STR@115..116 "`"
+    PUNCT_SEMI@116..117 ";"
+  WHITESPACE@117..119 "\n\n"
+  STMT@119..385
+    ITEM@119..384
+      EXPR@119..384
+        EXPR_LET@119..384
+          KW_LET@119..122 "let"
+          WHITESPACE@122..123 " "
+          IDENT@123..124 "a"
+          WHITESPACE@124..125 " "
+          OP_ASSIGN@125..126 "="
+          EXPR@126..384
+            WHITESPACE@126..127 " "
+            EXPR_LIT@127..384
+              LIT@127..384
+                LIT_STR_TEMPLATE@127..384
+                  LIT_STR@127..137 "`multiple "
+                  INTERPOLATION_START@137..139 "${"
+                  LIT_STR_TEMPLATE_INTERPOLATION@139..141
+                    STMT@139..141
+                      ITEM@139..141
+                        EXPR@139..141
+                          EXPR_IDENT@139..141
+                            IDENT@139..141 "hi"
+                  PUNCT_BRACE_END@141..142 "}"
+                  INTERPOLATION_START@142..144 "${"
+                  LIT_STR_TEMPLATE_INTERPOLATION@144..146
+                    STMT@144..146
+                      ITEM@144..146
+                        EXPR@144..146
+                          EXPR_IDENT@144..146
+                            IDENT@144..146 "hi"
+                  PUNCT_BRACE_END@146..147 "}"
+                  LIT_STR@147..148 " "
+                  INTERPOLATION_START@148..150 "${"
+                  LIT_STR_TEMPLATE_INTERPOLATION@150..152
+                    STMT@150..152
+                      ITEM@150..152
+                        EXPR@150..152
+                          EXPR_IDENT@150..152
+                            IDENT@150..152 "hi"
+                  PUNCT_BRACE_END@152..153 "}"
+                  LIT_STR@153..170 " \\interpolations "
+                  INTERPOLATION_START@170..172 "${"
+                  LIT_STR_TEMPLATE_INTERPOLATION@172..178
+                    STMT@172..178
+                      ITEM@172..178
+                        EXPR@172..178
+                          EXPR_BINARY@172..178
+                            EXPR@172..175
+                              EXPR_IDENT@172..175
+                                IDENT@172..174 "hi"
+                                WHITESPACE@174..175 " "
+                            OP_ADD@175..176 "+"
+                            EXPR@176..178
+                              WHITESPACE@176..177 " "
+                              EXPR_LIT@177..178
+                                LIT@177..178
+                                  LIT_INT@177..178 "2"
+                  PUNCT_BRACE_END@178..179 "}"
+                  LIT_STR@179..197 " and more complex "
+                  INTERPOLATION_START@197..199 "${"
+                  LIT_STR_TEMPLATE_INTERPOLATION@199..370
+                    WHITESPACE@199..204 "\n    "
+                    STMT@204..370
+                      ITEM@204..370
+                        EXPR@204..370
+                          EXPR_BLOCK@204..369
+                            PUNCT_BRACE_START@204..205 "{"
+                            WHITESPACE@205..214 "\n        "
+                            STMT@214..224
+                              ITEM@214..223
+                                EXPR@214..223
+                                  EXPR_LET@214..223
+                                    KW_LET@214..217 "let"
+                                    WHITESPACE@217..218 " "
+                                    IDENT@218..219 "a"
+                                    WHITESPACE@219..220 " "
+                                    OP_ASSIGN@220..221 "="
+                                    EXPR@221..223
+                                      WHITESPACE@221..222 " "
+                                      EXPR_LIT@222..223
+                                        LIT@222..223
+                                          LIT_INT@222..223 "2"
+                              PUNCT_SEMI@223..224 ";"
+                            WHITESPACE@224..233 "\n        "
+                            STMT@233..283
+                              ITEM@233..282
+                                EXPR@233..282
+                                  EXPR_LET@233..282
+                                    KW_LET@233..236 "let"
+                                    WHITESPACE@236..237 " "
+                                    IDENT@237..238 "b"
+                                    WHITESPACE@238..239 " "
+                                    OP_ASSIGN@239..240 "="
+                                    EXPR@240..282
+                                      WHITESPACE@240..241 " "
+                                      EXPR_LIT@241..282
+                                        LIT@241..282
+                                          LIT_STR_TEMPLATE@241..282
+                                            LIT_STR@241..249 "`nested "
+                                            INTERPOLATION_START@249..251 "${"
+                                            LIT_STR_TEMPLATE_INTERPOLATION@251..253
+                                              STMT@251..253
+                                                ITEM@251..253
+                                                  EXPR@251..253
+                                                    EXPR_IDENT@251..253
+                                                      IDENT@251..253 "hi"
+                                            PUNCT_BRACE_END@253..254 "}"
+                                            LIT_STR@254..269 " interpolation "
+                                            INTERPOLATION_START@269..271 "${"
+                                            LIT_STR_TEMPLATE_INTERPOLATION@271..280
+                                              WHITESPACE@271..272 " "
+                                              STMT@272..280
+                                                ITEM@272..280
+                                                  EXPR@272..280
+                                                    EXPR_BINARY@272..280
+                                                      EXPR@272..277
+                                                        EXPR_BINARY@272..277
+                                                          EXPR@272..273
+                                                            EXPR_LIT@272..273
+                                                              LIT@272..273
+                                                                LIT_INT@272..273 "3"
+                                                          OP_POW@273..275 "**"
+                                                          EXPR@275..277
+                                                            EXPR_LIT@275..276
+                                                              LIT@275..276
+                                                                LIT_INT@275..276 "3"
+                                                            WHITESPACE@276..277 " "
+                                                      OP_ADD@277..278 "+"
+                                                      EXPR@278..280
+                                                        WHITESPACE@278..279 " "
+                                                        EXPR_LIT@279..280
+                                                          LIT@279..280
+                                                            LIT_INT@279..280 "4"
+                                            PUNCT_BRACE_END@280..281 "}"
+                                            LIT_STR@281..282 "`"
+                              PUNCT_SEMI@282..283 ";"
+                            WHITESPACE@283..292 "\n        "
+                            STMT@292..349
+                              ITEM@292..348
+                                EXPR@292..348
+                                  EXPR_LET@292..348
+                                    KW_LET@292..295 "let"
+                                    WHITESPACE@295..296 " "
+                                    IDENT@296..297 "c"
+                                    WHITESPACE@297..298 " "
+                                    OP_ASSIGN@298..299 "="
+                                    EXPR@299..348
+                                      WHITESPACE@299..300 " "
+                                      EXPR_LIT@300..348
+                                        LIT@300..348
+                                          LIT_STR_TEMPLATE@300..348
+                                            LIT_STR@300..348 "`with escaped `` but  ..."
+                              PUNCT_SEMI@348..349 ";"
+                            WHITESPACE@349..358 "\n        "
+                            STMT@358..368
+                              ITEM@358..368
+                                EXPR@358..368
+                                  EXPR_BINARY@358..368
+                                    EXPR@358..360
+                                      EXPR_IDENT@358..360
+                                        IDENT@358..359 "a"
+                                        WHITESPACE@359..360 " "
+                                    OP_ADD@360..361 "+"
+                                    EXPR@361..368
+                                      WHITESPACE@361..362 " "
+                                      EXPR_IDENT@362..368
+                                        IDENT@362..363 "a"
+                                        WHITESPACE@363..368 "\n    "
+                            PUNCT_BRACE_END@368..369 "}"
+                          WHITESPACE@369..370 "\n"
+                  PUNCT_BRACE_END@370..371 "}"
+                  LIT_STR@371..384 " expressions`"
+    PUNCT_SEMI@384..385 ";"
+  WHITESPACE@385..386 "\n"
+

--- a/crates/sourcegen/src/syntax/decl.rs
+++ b/crates/sourcegen/src/syntax/decl.rs
@@ -14,6 +14,7 @@ pub(crate) fn token_name(token: &str) -> &'static str {
         "?[" => "PUNCT_NULL_BRACKET_START",
         "]" => "PUNCT_BRACKET_END",
         "#{" => "PUNCT_MAP_START",
+        "${" => "INTERPOLATION_START",
         "{" => "PUNCT_BRACE_START",
         "}" => "PUNCT_BRACE_END",
         "?" => "PUNCT_QUESTION_MARK",

--- a/testdata/valid/template.rhai
+++ b/testdata/valid/template.rhai
@@ -1,0 +1,14 @@
+let hi = 2;
+`${2}💩  💩   asd abc${3 + 2 + 1 + `${""}`}`;
+
+let a = `with \interpolation ${hi} `;
+let a = `${hi}`;
+
+let a = `multiple ${hi}${hi} ${hi} \interpolations ${hi + 2} and more complex ${
+    {
+        let a = 2;
+        let b = `nested ${hi} interpolation ${ 3**3 + 4}`;
+        let c = `with escaped `` but you cannot escape the \`` `;
+        a + a
+    }
+} expressions`;


### PR DESCRIPTION
I finally decided to tackle this.

The AST remained surprisingly simple, a string template literal now looks like this:

```
LitStrTemplate =
  ('lit_str' '${' LitStrTemplateInterpolation '}')* 'lit_str'
```

The first `lit_str` token always starts with a backtick, whereas the last `lit_str` always ends with one. If there are no intermediate interpolated blocks, the entire node really is just a single `lit_str`.

After encountering a backtick, I manually parse each string segment before/between/after interploated blocks. There was some trickery because this essentially bypasses most of the context and the tokenizer behind it which has to be advanced manually.

In the end this was a lot less work than I expected. That is until we encounter the edge-cases and bugs.

Closes #46.