### PR TITLE
First-class types and type inference

### DIFF
--- a/crates/rhai-hir/src/hir/add/def.rs
+++ b/crates/rhai-hir/src/hir/add/def.rs
@@ -305,7 +305,11 @@ impl Hir {
                     .children_with_tokens()
                     .filter_map(SyntaxElement::into_token)
                     .skip(1)
-                    .find(|t| t.kind() == T!["ident"] || t.kind().infix_binding_power().is_some());
+                    .find(|t| {
+                        t.kind() == T!["ident"]
+                            || t.kind().infix_binding_power().is_some()
+                            || t.kind().prefix_binding_power().is_some()
+                    });
 
                 let ident = match name_token {
                     Some(i) => i,
@@ -362,7 +366,7 @@ impl Hir {
                     },
                     parent_scope: Scope::default(),
                     kind: SymbolKind::Op(OpSymbol {
-                        name: ident.text().into(),
+                        name: ident.text().trim().into(),
                         docs,
                         binding_powers: f
                             .precedence()

--- a/crates/rhai-hir/src/hir/add/mod.rs
+++ b/crates/rhai-hir/src/hir/add/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     module::{ModuleKind, STATIC_URL_SCHEME},
     scope::ScopeParent,
     source::SourceKind,
-    Type,
+    TypeKind,
 };
 use rhai_rowan::{
     ast::{AstNode, Rhai, RhaiDef},
@@ -63,6 +63,57 @@ impl Hir {
                 module: self.static_module,
             });
             self.virtual_source = source;
+        }
+    }
+
+    pub(crate) fn ensure_builtin_types(&mut self) {
+        // If any of them is not null, it has been
+        // initialized.
+        if !self.builtin_types.is_uninit() {
+            return;
+        }
+
+        self.builtin_types = BuiltinTypes {
+            module: self.types.insert(TypeData {
+                kind: TypeKind::Module,
+                ..TypeData::default()
+            }),
+            int: self.types.insert(TypeData {
+                kind: TypeKind::Int,
+                ..TypeData::default()
+            }),
+            float: self.types.insert(TypeData {
+                kind: TypeKind::Float,
+                ..TypeData::default()
+            }),
+            bool: self.types.insert(TypeData {
+                kind: TypeKind::Bool,
+                ..TypeData::default()
+            }),
+            char: self.types.insert(TypeData {
+                kind: TypeKind::Char,
+                ..TypeData::default()
+            }),
+            string: self.types.insert(TypeData {
+                kind: TypeKind::String,
+                ..TypeData::default()
+            }),
+            timestamp: self.types.insert(TypeData {
+                kind: TypeKind::Timestamp,
+                ..TypeData::default()
+            }),
+            void: self.types.insert(TypeData {
+                kind: TypeKind::Void,
+                ..TypeData::default()
+            }),
+            unknown: self.types.insert(TypeData {
+                kind: TypeKind::Unknown,
+                ..TypeData::default()
+            }),
+            never: self.types.insert(TypeData {
+                kind: TypeKind::Never,
+                ..TypeData::default()
+            }),
         }
     }
 
@@ -127,6 +178,7 @@ impl Hir {
                         module,
                     })),
                     export: true,
+                    ty: self.builtin_types.unknown,
                 });
 
                 self[self.static_module]

--- a/crates/rhai-hir/src/hir/add/script.rs
+++ b/crates/rhai-hir/src/hir/add/script.rs
@@ -382,6 +382,10 @@ impl Hir {
                         selection_text_range: None,
                     },
                     kind: SymbolKind::Unary(UnarySymbol {
+                        lookup_text: expr
+                            .op_token()
+                            .map(|t| t.text().trim().to_string())
+                            .unwrap_or_default(),
                         op: expr.op_token().map(|t| t.kind()),
                         rhs,
                     }),
@@ -438,6 +442,10 @@ impl Hir {
                     },
                     kind: SymbolKind::Binary(BinarySymbol {
                         scope: binary_scope,
+                        lookup_text: expr
+                            .op_token()
+                            .map(|t| t.text().trim().to_string())
+                            .unwrap_or_default(),
                         lhs,
                         op,
                         rhs,

--- a/crates/rhai-hir/src/hir/errors.rs
+++ b/crates/rhai-hir/src/hir/errors.rs
@@ -45,7 +45,7 @@ impl Hir {
                     }
                 }
                 SymbolKind::Fn(f) => {
-                    if f.def {
+                    if f.is_def {
                         return;
                     }
 

--- a/crates/rhai-hir/src/hir/query/mod.rs
+++ b/crates/rhai-hir/src/hir/query/mod.rs
@@ -5,6 +5,7 @@ use super::*;
 
 pub mod modules;
 pub mod scope_iter;
+pub mod types;
 
 // Nested ranges only.
 fn range_scope(r1: TextRange, r2: TextRange) -> Ordering {

--- a/crates/rhai-hir/src/hir/query/scope_iter.rs
+++ b/crates/rhai-hir/src/hir/query/scope_iter.rs
@@ -354,6 +354,7 @@ fn collect_symbol_scope_iters<'h>(
         | SymbolKind::Reference(_)
         | SymbolKind::Continue(_)
         | SymbolKind::Discard(_)
-        | SymbolKind::Virtual(VirtualSymbol::Proxy(..)) => {}
+        | SymbolKind::Virtual(VirtualSymbol::Proxy(..))
+        | SymbolKind::TypeDecl(_) => {}
     }
 }

--- a/crates/rhai-hir/src/hir/query/types.rs
+++ b/crates/rhai-hir/src/hir/query/types.rs
@@ -1,0 +1,9 @@
+use crate::{hir::BuiltinTypes, Hir};
+
+impl Hir {
+    #[must_use]
+    #[inline]
+    pub const fn builtin_types(&self) -> BuiltinTypes {
+        self.builtin_types
+    }
+}

--- a/crates/rhai-hir/src/hir/remove.rs
+++ b/crates/rhai-hir/src/hir/remove.rs
@@ -16,8 +16,19 @@ impl Hir {
             .map(|(s, _)| s)
             .collect::<Vec<_>>();
 
+        let types_to_remove = self
+            .types
+            .iter()
+            .filter(|(_, ty_data)| ty_data.source.is(source))
+            .map(|(s, _)| s)
+            .collect::<Vec<_>>();
+
         for symbol in symbols_to_remove {
             self.remove_symbol(symbol);
+        }
+
+        for ty in types_to_remove {
+            self.types.remove(ty);
         }
 
         for m in self.modules.values_mut() {
@@ -242,7 +253,7 @@ impl Hir {
                     self.remove_scope(scope);
                 }
             }
-             SymbolKind::Continue(_) | SymbolKind::Discard(_) => {}
+            SymbolKind::Continue(_) | SymbolKind::Discard(_) => {}
             SymbolKind::Export(e) => {
                 if let Some(s) = e.target {
                     self.remove_symbol(s);

--- a/crates/rhai-hir/src/hir/remove.rs
+++ b/crates/rhai-hir/src/hir/remove.rs
@@ -141,6 +141,7 @@ impl Hir {
                 }
             }
             SymbolKind::Binary(binary) => {
+                self.remove_scope(binary.scope);
                 if let Some(s) = binary.lhs {
                     self.remove_symbol(s);
                 }

--- a/crates/rhai-hir/src/hir/resolve/mod.rs
+++ b/crates/rhai-hir/src/hir/resolve/mod.rs
@@ -26,7 +26,7 @@ impl Hir {
 
     pub fn resolve_all(&mut self) {
         self.resolve_references();
-        self.resolve_types_for_all_symbols();
+        self.resolve_types();
     }
 
     pub fn resolve_references(&mut self) {

--- a/crates/rhai-hir/src/hir/resolve/mod.rs
+++ b/crates/rhai-hir/src/hir/resolve/mod.rs
@@ -41,6 +41,7 @@ impl Hir {
     }
 
     pub fn resolve_types(&mut self) {
+        self.resolve_type_aliases();
         self.resolve_types_for_all_symbols();
     }
 

--- a/crates/rhai-hir/src/hir/resolve/mod.rs
+++ b/crates/rhai-hir/src/hir/resolve/mod.rs
@@ -1,10 +1,11 @@
-use itertools::Itertools;
-use url::Url;
-
 use crate::{
     symbol::{ReferenceTarget, SymbolKind, VirtualSymbol},
     Hir, Module, Symbol,
 };
+use itertools::Itertools;
+use url::Url;
+
+mod types;
 
 impl Hir {
     pub fn clear_references(&mut self) {
@@ -23,6 +24,11 @@ impl Hir {
         }
     }
 
+    pub fn resolve_all(&mut self) {
+        self.resolve_references();
+        self.resolve_types_for_all_symbols();
+    }
+
     pub fn resolve_references(&mut self) {
         self.clear_references();
 
@@ -32,6 +38,10 @@ impl Hir {
         self.resolve_imports();
         self.resolve_paths();
         self.resolve_scope_references();
+    }
+
+    pub fn resolve_types(&mut self) {
+        self.resolve_types_for_all_symbols();
     }
 
     fn resolve_scope_references(&mut self) {
@@ -188,7 +198,9 @@ impl Hir {
                                         visible_symbol = import_alias;
                                     }
                                     SymbolKind::Virtual(VirtualSymbol::Module(m)) => {
-                                        if self[module_reference].name(self) != Some(m.name.as_str()) {
+                                        if self[module_reference].name(self)
+                                            != Some(m.name.as_str())
+                                        {
                                             continue;
                                         }
                                     }

--- a/crates/rhai-hir/src/hir/resolve/types.rs
+++ b/crates/rhai-hir/src/hir/resolve/types.rs
@@ -413,12 +413,14 @@ impl Hir {
                 let lookup_text = b.lookup_text.clone();
 
                 let ty = if b.is_field_access() {
-                    lhs.and_then(|lhs| self[self[lhs].ty].kind.as_object())
-                        .and_then(|object| {
-                            Some((object, rhs.and_then(|rhs| self[rhs].name(self))?))
-                        })
-                        .and_then(|(object, field_name)| object.fields.get(field_name))
-                        .copied()
+                    lhs.map(|lhs| {
+                        self.resolve_type_for_symbol(seen, lhs);
+                        lhs
+                    })
+                    .and_then(|lhs| self[self[lhs].ty].kind.as_object())
+                    .and_then(|object| Some((object, rhs.and_then(|rhs| self[rhs].name(self))?)))
+                    .and_then(|(object, field_name)| object.fields.get(field_name))
+                    .copied()
                 } else {
                     match (lhs, rhs) {
                         (Some(lhs), Some(rhs)) => {

--- a/crates/rhai-hir/src/hir/resolve/types.rs
+++ b/crates/rhai-hir/src/hir/resolve/types.rs
@@ -1,0 +1,311 @@
+use crate::{
+    eval::Value,
+    symbol::{ReferenceTarget, SymbolKind},
+    ty::{Array, Function, Object, TypeData},
+    Hir, IndexMap, IndexSet, Symbol, TypeKind,
+};
+
+impl Hir {
+    pub(crate) fn resolve_types_for_all_symbols(&mut self) {
+        let symbols = self.symbols.keys().collect::<Vec<_>>();
+
+        for symbol in symbols {
+            self.resolve_type_for_symbol(symbol);
+        }
+    }
+
+    // An intermediate collect is sometimes required to satisfy
+    // the borrow-checker. We operate on multiple elements of the 
+    // same slotmap. Even if we know that the operations are disjoint,
+    // the borrow-checker does not, and we need to index into it again,
+    // or sometimes collect intermediate values into a vec.
+    // This makes some operations somewhat more inefficient, but at the same
+    // time some subtle bugs are turned into panics instead.
+    #[allow(clippy::needless_collect)]
+    pub(crate) fn resolve_type_for_symbol(&mut self, symbol: Symbol) {
+        let sym_data = self.symbols.get_mut(symbol).unwrap();
+        let source = sym_data.source;
+
+        #[allow(clippy::match_same_arms)]
+        match &sym_data.kind {
+            SymbolKind::Lit(lit) => {
+                sym_data.ty = match &lit.value {
+                    Value::Int(_) => self.builtin_types.int,
+                    Value::Float(_) => self.builtin_types.float,
+                    Value::Bool(_) => self.builtin_types.bool,
+                    Value::String(_) => self.builtin_types.string,
+                    Value::Char(_) => self.builtin_types.char,
+                    Value::Unknown => self.builtin_types.unknown,
+                }
+            }
+            SymbolKind::Reference(r) => match r.target {
+                Some(ReferenceTarget::Symbol(target_sym)) => {
+                    let target_sym_data = self.symbols.get(target_sym).unwrap();
+                    self.symbols.get_mut(symbol).unwrap().ty = target_sym_data.ty;
+                }
+                Some(ReferenceTarget::Module(_)) => {
+                    sym_data.ty = self.builtin_types.module;
+                }
+                None => sym_data.ty = self.builtin_types.unknown,
+            },
+            SymbolKind::Decl(decl) => {
+                let ty = if let Some(ty) = decl.ty_decl {
+                    ty
+                } else if let Some(val) = decl.value {
+                    self.symbols.get(val).unwrap().ty
+                } else {
+                    self.builtin_types.unknown
+                };
+
+                self.symbols.get_mut(symbol).unwrap().ty = ty;
+            }
+            SymbolKind::Block(block) => {
+                if let Some(last_symbol) = self
+                    .scopes
+                    .get(block.scope)
+                    .unwrap()
+                    .symbols
+                    .last()
+                    .copied()
+                {
+                    self.symbols.get_mut(symbol).unwrap().ty =
+                        self.symbols.get(last_symbol).unwrap().ty;
+                }
+            }
+            SymbolKind::Switch(switch) => {
+                let mut switch_types = IndexSet::default();
+                let switch_arm_exprs = switch
+                    .arms
+                    .iter()
+                    .filter_map(|arm| arm.value_expr)
+                    .collect::<Vec<_>>();
+                for arm_expr in switch_arm_exprs {
+                    switch_types.insert(self.symbols.get(arm_expr).unwrap().ty);
+                }
+                self.symbols.get_mut(symbol).unwrap().ty = if switch_types.is_empty() {
+                    self.builtin_types.void
+                } else if switch_types.len() == 1 {
+                    switch_types.pop().unwrap()
+                } else {
+                    self.types.insert(TypeData {
+                        source,
+                        kind: TypeKind::Union(switch_types),
+                    })
+                };
+            }
+            SymbolKind::If(if_sym) => {
+                let branch_symbols = if_sym
+                    .branches
+                    .iter()
+                    .map(|(_, scope)| self.scopes.get(*scope).unwrap().symbols.last().copied())
+                    .collect::<Vec<_>>();
+
+                let mut branch_types = branch_symbols
+                    .into_iter()
+                    .map(|sym| match sym {
+                        Some(last_branch_sym) => self.symbols.get(last_branch_sym).unwrap().ty,
+                        None => self.builtin_types.void,
+                    })
+                    .collect::<IndexSet<_>>();
+
+                self.symbols.get_mut(symbol).unwrap().ty = if branch_types.is_empty() {
+                    self.builtin_types.void
+                } else if branch_types.len() == 1 {
+                    branch_types.pop().unwrap()
+                } else {
+                    self.types.insert(TypeData {
+                        source,
+                        kind: TypeKind::Union(branch_types),
+                    })
+                };
+            }
+            SymbolKind::Fn(f) => {
+                let scope = f.scope;
+                let is_def = f.is_def;
+
+                let ret_ty = if is_def && f.ret_ty == self.builtin_types.unknown {
+                    self.builtin_types.void
+                } else {
+                    f.ret_ty
+                };
+
+                let params = self
+                    .scopes
+                    .get(f.scope)
+                    .unwrap()
+                    .symbols
+                    .iter()
+                    .copied()
+                    .take_while(|&sym| self.symbols.get(sym).unwrap().is_param())
+                    .map(|sym| {
+                        let sym_data = self.symbols.get(sym).unwrap();
+                        let decl = sym_data.kind.as_decl().unwrap();
+                        (decl.name.clone(), sym_data.ty)
+                    })
+                    .collect::<Vec<_>>();
+
+                let ret = if is_def {
+                    ret_ty
+                } else if let Some(last_expr) = self
+                    .scopes
+                    .get(scope)
+                    .unwrap()
+                    .symbols
+                    .iter()
+                    .copied()
+                    .find(|&sym| !self.symbols.get(sym).unwrap().is_param())
+                {
+                    self.symbols.get(last_expr).unwrap().ty
+                } else {
+                    self.builtin_types.unknown
+                };
+
+                self.symbols.get_mut(symbol).unwrap().ty = self.types.insert(TypeData {
+                    source,
+                    kind: TypeKind::Fn(Function {
+                        is_closure: false,
+                        params,
+                        ret,
+                    }),
+                });
+            }
+            SymbolKind::Closure(f) => {
+                let scope = f.scope;
+
+                let params = self
+                    .scopes
+                    .get(f.scope)
+                    .unwrap()
+                    .symbols
+                    .iter()
+                    .copied()
+                    .take_while(|&sym| self.symbols.get(sym).unwrap().is_param())
+                    .map(|sym| {
+                        let sym_data = self.symbols.get(sym).unwrap();
+                        let decl = sym_data.kind.as_decl().unwrap();
+                        (decl.name.clone(), sym_data.ty)
+                    })
+                    .collect::<Vec<_>>();
+
+                let ret = if let Some(last_expr) = self
+                    .scopes
+                    .get(scope)
+                    .unwrap()
+                    .symbols
+                    .iter()
+                    .copied()
+                    .find(|&sym| !self.symbols.get(sym).unwrap().is_param())
+                {
+                    self.symbols.get(last_expr).unwrap().ty
+                } else {
+                    self.builtin_types.unknown
+                };
+
+                self.symbols.get_mut(symbol).unwrap().ty = self.types.insert(TypeData {
+                    source,
+                    kind: TypeKind::Fn(Function {
+                        is_closure: false,
+                        params,
+                        ret,
+                    }),
+                });
+            }
+            SymbolKind::Call(call) => {
+                if let Some(lhs) = call.lhs {
+                    let ty_data = self.types.get(self.symbols.get(lhs).unwrap().ty).unwrap();
+
+                    let ty = if let Some(ty_fn) = ty_data.kind.as_fn() {
+                        ty_fn.ret
+                    } else {
+                        self.builtin_types.unknown
+                    };
+
+                    self.symbols.get_mut(symbol).unwrap().ty = ty;
+                }
+            }
+            SymbolKind::Index(idx) => {
+                if let Some(base) = idx.base {
+                    let ty_data = self.types.get(self.symbols.get(base).unwrap().ty).unwrap();
+
+                    let ty = if let Some(arr) = ty_data.kind.as_array() {
+                        arr.items
+                    } else {
+                        self.builtin_types.unknown
+                    };
+
+                    self.symbols.get_mut(symbol).unwrap().ty = ty;
+                }
+            }
+            SymbolKind::Array(arr) => {
+                let types = arr.values.clone();
+
+                let mut types = types
+                    .into_iter()
+                    .map(|sym| self.symbols.get(sym).unwrap().ty)
+                    .collect::<IndexSet<_>>();
+
+                let items = if types.is_empty() {
+                    self.builtin_types.void
+                } else if types.len() == 1 {
+                    types.pop().unwrap()
+                } else {
+                    self.types.insert(TypeData {
+                        source,
+                        kind: TypeKind::Union(types),
+                    })
+                };
+
+                let arr_ty = self.types.insert(TypeData {
+                    source,
+                    kind: TypeKind::Array(Array { items }),
+                });
+
+                self.symbols.get_mut(symbol).unwrap().ty = arr_ty;
+            }
+            SymbolKind::Object(o) => {
+                let fields = o
+                    .fields
+                    .iter()
+                    .filter_map(|(name, field)| field.value.map(|val| (name.clone(), val)))
+                    .collect::<Vec<_>>();
+
+                let fields = fields
+                    .into_iter()
+                    .map(|(name, sym)| (name, self.symbols.get(sym).unwrap().ty))
+                    .collect::<IndexMap<_, _>>();
+
+                self.symbols.get_mut(symbol).unwrap().ty = self.types.insert(TypeData {
+                    source,
+                    kind: TypeKind::Object(Object { fields }),
+                });
+            }
+
+            SymbolKind::Path(p) => {
+                if let Some(&path_sym) = p.segments.last() {
+                    self.symbols.get_mut(symbol).unwrap().ty =
+                        self.symbols.get(path_sym).unwrap().ty;
+                }
+            }
+            SymbolKind::Throw(_)
+            | SymbolKind::Break(_)
+            | SymbolKind::Continue(_)
+            | SymbolKind::Return(_)
+            | SymbolKind::Virtual(_)
+            | SymbolKind::Discard(_)
+            | SymbolKind::Op(_)
+            | SymbolKind::Try(_) => {
+                sym_data.ty = self.builtin_types.never;
+            }
+            SymbolKind::Import(_)
+            | SymbolKind::Export(_)
+            | SymbolKind::For(_)
+            | SymbolKind::Loop(_)
+            | SymbolKind::While(_) => {
+                sym_data.ty = self.builtin_types.void;
+            }
+            SymbolKind::Unary(_) | SymbolKind::Binary(_) => {
+                // TODO
+            }
+        }
+    }
+}

--- a/crates/rhai-hir/src/lib.rs
+++ b/crates/rhai-hir/src/lib.rs
@@ -30,4 +30,4 @@ pub use hir::Hir;
 pub use module::Module;
 pub use scope::Scope;
 pub use symbol::Symbol;
-pub use ty::Type;
+pub use ty::TypeKind;

--- a/crates/rhai-hir/src/scope.rs
+++ b/crates/rhai-hir/src/scope.rs
@@ -3,6 +3,7 @@ use crate::{source::SourceInfo, HashSet, IndexSet, Symbol};
 slotmap::new_key_type! { pub struct Scope; }
 
 #[derive(Debug, Default, Clone)]
+#[non_exhaustive]
 pub struct ScopeData {
     pub source: SourceInfo,
     pub parent: Option<ScopeParent>,

--- a/crates/rhai-hir/src/scope.rs
+++ b/crates/rhai-hir/src/scope.rs
@@ -38,6 +38,26 @@ pub enum ScopeParent {
     Symbol(Symbol),
 }
 
+impl ScopeParent {
+    #[must_use]
+    pub fn as_scope(&self) -> Option<&Scope> {
+        if let Self::Scope(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    pub fn as_symbol(&self) -> Option<&Symbol> {
+        if let Self::Symbol(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
 impl From<Scope> for ScopeParent {
     fn from(s: Scope) -> Self {
         Self::Scope(s)

--- a/crates/rhai-hir/src/source.rs
+++ b/crates/rhai-hir/src/source.rs
@@ -6,6 +6,7 @@ use crate::Module;
 slotmap::new_key_type! { pub struct Source; }
 
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct SourceData {
     pub url: Url,
     pub kind: SourceKind,

--- a/crates/rhai-hir/src/symbol.rs
+++ b/crates/rhai-hir/src/symbol.rs
@@ -744,6 +744,7 @@ pub struct UnarySymbol {
 
 #[derive(Debug, Clone)]
 pub struct BinarySymbol {
+    pub scope: Scope,
     pub lhs: Option<Symbol>,
     pub op: Option<BinaryOpKind>,
     pub rhs: Option<Symbol>,

--- a/crates/rhai-hir/src/symbol.rs
+++ b/crates/rhai-hir/src/symbol.rs
@@ -738,6 +738,7 @@ pub struct LitSymbol {
 
 #[derive(Debug, Clone)]
 pub struct UnarySymbol {
+    pub lookup_text: String,
     pub op: Option<SyntaxKind>,
     pub rhs: Option<Symbol>,
 }
@@ -745,9 +746,17 @@ pub struct UnarySymbol {
 #[derive(Debug, Clone)]
 pub struct BinarySymbol {
     pub scope: Scope,
+    pub lookup_text: String,
     pub lhs: Option<Symbol>,
     pub op: Option<BinaryOpKind>,
     pub rhs: Option<Symbol>,
+}
+
+impl BinarySymbol {
+    #[must_use]
+    pub fn is_field_access(&self) -> bool {
+        self.lookup_text == "."
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rhai-hir/src/symbol.rs
+++ b/crates/rhai-hir/src/symbol.rs
@@ -126,6 +126,7 @@ pub enum SymbolKind {
     Import(ImportSymbol),
     Discard(DiscardSymbol),
     Virtual(VirtualSymbol),
+    TypeDecl(TypeDeclSymbol),
 }
 
 impl SymbolKind {
@@ -649,6 +650,23 @@ impl SymbolKind {
             None
         }
     }
+
+    /// Returns `true` if the symbol kind is [`TypeDecl`].
+    ///
+    /// [`TypeDecl`]: SymbolKind::TypeDecl
+    #[must_use]
+    pub fn is_type_decl(&self) -> bool {
+        matches!(self, Self::TypeDecl(..))
+    }
+
+    #[must_use]
+    pub fn as_type_decl(&self) -> Option<&TypeDeclSymbol> {
+        if let Self::TypeDecl(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1026,4 +1044,10 @@ pub struct VirtualProxySymbol {
 pub struct VirtualModuleSymbol {
     pub name: String,
     pub module: Module,
+}
+
+#[derive(Debug, Clone)]
+pub struct TypeDeclSymbol {
+    pub docs: String,
+    pub ty: Type,
 }

--- a/crates/rhai-hir/src/symbol.rs
+++ b/crates/rhai-hir/src/symbol.rs
@@ -923,6 +923,42 @@ pub enum ReferenceTarget {
     Module(Module),
 }
 
+impl ReferenceTarget {
+    /// Returns `true` if the reference target is [`Symbol`].
+    ///
+    /// [`Symbol`]: ReferenceTarget::Symbol
+    #[must_use]
+    pub fn is_symbol(&self) -> bool {
+        matches!(self, Self::Symbol(..))
+    }
+
+    #[must_use]
+    pub fn as_symbol(&self) -> Option<&Symbol> {
+        if let Self::Symbol(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Returns `true` if the reference target is [`Module`].
+    ///
+    /// [`Module`]: ReferenceTarget::Module
+    #[must_use]
+    pub fn is_module(&self) -> bool {
+        matches!(self, Self::Module(..))
+    }
+
+    #[must_use]
+    pub fn as_module(&self) -> Option<&Module> {
+        if let Self::Module(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
 /// A symbol that does not and cannot originate
 /// from source code and was injected into the hir.
 #[derive(Debug, Clone)]

--- a/crates/rhai-hir/src/ty.rs
+++ b/crates/rhai-hir/src/ty.rs
@@ -9,6 +9,29 @@ impl Type {
     pub fn fmt(self, hir: &Hir) -> TypeFormatter {
         TypeFormatter { hir, ty: self }
     }
+
+    /// Comparison to other type via the HIR.
+    ///
+    /// Types are considered equal if the type itself is the same
+    /// or if both types are unresolved and their names are the same.
+    /// 
+    /// If `exact` is false, types are equal if at least one of them
+    /// are unknown.
+    #[must_use]
+    pub fn is(self, hir: &Hir, other: Type, exact: bool) -> bool {
+        if self == other {
+            return true;
+        }
+
+        let this = &hir[self];
+        let other = &hir[other];
+
+        match (&this.kind, &other.kind) {
+            (TypeKind::Unknown, _) | (_, TypeKind::Unknown) if !exact => true,
+            (TypeKind::Unresolved(ty1), TypeKind::Unresolved(ty2)) => ty1 == ty2,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/rhai-hir/src/ty.rs
+++ b/crates/rhai-hir/src/ty.rs
@@ -27,7 +27,7 @@ impl Type {
         let other = &hir[other];
 
         match (&this.kind, &other.kind) {
-            (TypeKind::Unknown, _) | (_, TypeKind::Unknown) if !exact => true,
+            (TypeKind::Unknown, _) | (_, TypeKind::Unknown) => !exact,
             (TypeKind::Unresolved(ty1), TypeKind::Unresolved(ty2)) => ty1 == ty2,
             _ => false,
         }

--- a/crates/rhai-hir/src/ty.rs
+++ b/crates/rhai-hir/src/ty.rs
@@ -63,6 +63,7 @@ impl Type {
 pub struct TypeData {
     pub source: SourceInfo,
     pub kind: TypeKind,
+    pub protected: bool,
 }
 
 /// Used to print a type.
@@ -157,6 +158,7 @@ impl core::fmt::Display for TypeFormatter<'_> {
             TypeKind::Unresolved(ty) => f.write_str(ty.trim())?,
             TypeKind::Never => f.write_str("!")?,
             TypeKind::Unknown => f.write_str("?")?,
+            TypeKind::Primitive(ty) => f.write_str(ty)?,
         }
 
         Ok(())
@@ -180,6 +182,8 @@ pub enum TypeKind {
     Alias(String, Type),
     Unresolved(String),
     Tuple(Vec<Type>),
+    /// An arbitrary atomic primitive type.
+    Primitive(String),
     Never,
     Unknown,
 }

--- a/crates/rhai-hir/src/ty.rs
+++ b/crates/rhai-hir/src/ty.rs
@@ -125,31 +125,6 @@ impl core::fmt::Display for TypeFormatter<'_> {
     }
 }
 
-// impl TypeData {
-//     fn to_writer(&self, hir: &Hir, writer: &mut dyn fmt::Write) -> fmt::Result {
-//         match &self.kind {
-//             TypeKind::Module => writer.write_str("module")?,
-//             TypeKind::Int => writer.write_str("int"),
-//             TypeKind::Float => todo!(),
-//             TypeKind::Bool => todo!(),
-//             TypeKind::Char => todo!(),
-//             TypeKind::String => todo!(),
-//             TypeKind::Timestamp => todo!(),
-//             TypeKind::Array(_) => todo!(),
-//             TypeKind::Object(_) => todo!(),
-//             TypeKind::Union(_) => todo!(),
-//             TypeKind::Void => todo!(),
-//             TypeKind::Fn(_) => todo!(),
-//             TypeKind::Alias(_, _) => todo!(),
-//             TypeKind::Unresolved(_) => todo!(),
-//             TypeKind::Never => todo!(),
-//             TypeKind::Unknown => todo!(),
-//         }
-
-//         Ok(())
-//     }
-// }
-
 #[derive(Debug, Clone)]
 pub enum TypeKind {
     Module,

--- a/crates/rhai-hir/src/ty.rs
+++ b/crates/rhai-hir/src/ty.rs
@@ -1,8 +1,134 @@
 #![allow(dead_code)]
-use std::mem;
+use crate::{source::SourceInfo, Hir, IndexMap, IndexSet};
+use core::fmt;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum Type {
+slotmap::new_key_type! { pub struct Type; }
+
+impl Type {
+    #[must_use]
+    pub fn fmt(self, hir: &Hir) -> TypeFormatter {
+        TypeFormatter { hir, ty: self }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub struct TypeData {
+    pub source: SourceInfo,
+    pub kind: TypeKind,
+}
+
+/// Used to print a type.
+pub struct TypeFormatter<'a> {
+    hir: &'a Hir,
+    ty: Type,
+}
+
+impl core::fmt::Display for TypeFormatter<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = &self.hir[self.ty];
+
+        match &data.kind {
+            TypeKind::Module => f.write_str("module")?,
+            TypeKind::Int => f.write_str("int")?,
+            TypeKind::Float => f.write_str("float")?,
+            TypeKind::Bool => f.write_str("bool")?,
+            TypeKind::Char => f.write_str("char")?,
+            TypeKind::String => f.write_str("String")?,
+            TypeKind::Timestamp => f.write_str("timestamp")?,
+            TypeKind::Array(arr) => {
+                f.write_str("[")?;
+                write!(f, "{}", arr.items.fmt(self.hir))?;
+                f.write_str("]")?;
+            }
+            TypeKind::Object(obj) => {
+                f.write_str("#{")?;
+
+                let mut first = true;
+                for (name, ty) in &obj.fields {
+                    if !first {
+                        f.write_str(", ")?;
+                    }
+                    first = false;
+
+                    write!(f, "{name}: {}", ty.fmt(self.hir))?;
+                }
+                f.write_str("}")?;
+            }
+            TypeKind::Union(tys) => {
+                let mut first = true;
+                for ty in tys {
+                    if !first {
+                        f.write_str("| ")?;
+                    }
+                    first = false;
+
+                    write!(f, "{}", ty.fmt(self.hir))?;
+                }
+            }
+            TypeKind::Void => f.write_str("()")?,
+            TypeKind::Fn(func) => {
+                if func.is_closure {
+                    f.write_str("|")?;
+                } else {
+                    f.write_str("fn (")?;
+                }
+
+                let mut first = true;
+                for (name, ty) in &func.params {
+                    if !first {
+                        f.write_str(", ")?;
+                    }
+                    first = false;
+
+                    write!(f, "{name}: {}", ty.fmt(self.hir))?;
+                }
+
+                if func.is_closure {
+                    f.write_str("|")?;
+                } else {
+                    f.write_str(")")?;
+                }
+
+                write!(f, " -> {}", func.ret.fmt(self.hir))?;
+            }
+            TypeKind::Alias(alias, _) => f.write_str(alias.trim())?,
+            TypeKind::Unresolved(ty) => f.write_str(ty.trim())?,
+            TypeKind::Never => f.write_str("!")?,
+            TypeKind::Unknown => f.write_str("?")?,
+        }
+
+        Ok(())
+    }
+}
+
+// impl TypeData {
+//     fn to_writer(&self, hir: &Hir, writer: &mut dyn fmt::Write) -> fmt::Result {
+//         match &self.kind {
+//             TypeKind::Module => writer.write_str("module")?,
+//             TypeKind::Int => writer.write_str("int"),
+//             TypeKind::Float => todo!(),
+//             TypeKind::Bool => todo!(),
+//             TypeKind::Char => todo!(),
+//             TypeKind::String => todo!(),
+//             TypeKind::Timestamp => todo!(),
+//             TypeKind::Array(_) => todo!(),
+//             TypeKind::Object(_) => todo!(),
+//             TypeKind::Union(_) => todo!(),
+//             TypeKind::Void => todo!(),
+//             TypeKind::Fn(_) => todo!(),
+//             TypeKind::Alias(_, _) => todo!(),
+//             TypeKind::Unresolved(_) => todo!(),
+//             TypeKind::Never => todo!(),
+//             TypeKind::Unknown => todo!(),
+//         }
+
+//         Ok(())
+//     }
+// }
+
+#[derive(Debug, Clone)]
+pub enum TypeKind {
     Module,
     Int,
     Float,
@@ -12,203 +138,200 @@ pub enum Type {
     Timestamp,
     Array(Array),
     Object(Object),
-    Union(Vec<Type>),
+    Union(IndexSet<Type>),
     Void,
-    Custom(String),
     Fn(Function),
+    Alias(String, Type),
+    Unresolved(String),
+    Never,
     Unknown,
 }
 
-impl core::fmt::Display for Type {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Type::Module => f.write_str("module")?,
-            Type::Int => f.write_str("int")?,
-            Type::Float => f.write_str("float")?,
-            Type::Bool => f.write_str("bool")?,
-            Type::Char => f.write_str("char")?,
-            Type::String => f.write_str("string")?,
-            Type::Timestamp => f.write_str("timestamp")?,
-            Type::Array(_) => f.write_str("array")?,
-            Type::Object(obj) => {
-                if f.alternate() {
-                    if obj.fields.is_empty() {
-                        return f.write_str("#{ }");
-                    }
-
-                    f.write_str("#{\n")?;
-
-                    for (field_name, field_ty) in &obj.fields {
-                        f.write_str("  ")?;
-                        f.write_str(field_name)?;
-                        f.write_str(": ")?;
-                        field_ty.fmt(f)?;
-                        f.write_str("\n")?;
-                    }
-
-                    f.write_str("}")?;
-                } else {
-                    f.write_str("object")?;
-                }
-            }
-            Type::Union(_) => f.write_str("union")?,
-            Type::Void => f.write_str("void")?,
-            Type::Custom(c) => f.write_str(c)?,
-            Type::Fn(ty) => {
-                if f.alternate() {
-                    if ty.is_closure {
-                        f.write_str("|")?;
-                    } else {
-                        f.write_str("(")?;
-                    }
-
-                    let mut first = true;
-                    for (param_name, param_ty) in &ty.params {
-                        if !first {
-                            f.write_str(", ")?;
-                        }
-
-                        f.write_str(param_name)?;
-
-                        f.write_str(": ")?;
-
-                        param_ty.fmt(f)?;
-
-                        first = false;
-                    }
-
-                    if ty.is_closure {
-                        f.write_str("|")?;
-                    } else {
-                        f.write_str(")")?;
-                    }
-
-                    f.write_str(" -> ")?;
-                    ty.ret.fmt(f)?;
-                } else {
-                    f.write_str("function")?;
-                }
-            }
-            Type::Unknown => f.write_str("?")?,
-        };
-
-        Ok(())
+impl TypeKind {
+    /// Returns `true` if the type kind is [`Module`].
+    ///
+    /// [`Module`]: TypeKind::Module
+    #[must_use]
+    pub fn is_module(&self) -> bool {
+        matches!(self, Self::Module)
     }
-}
 
-impl Type {
-    pub(crate) fn dedup(&mut self) {
-        if let Type::Union(u) = self {
-            u.dedup();
-            for sub in u {
-                sub.dedup();
-            }
+    /// Returns `true` if the type kind is [`Int`].
+    ///
+    /// [`Int`]: TypeKind::Int
+    #[must_use]
+    pub fn is_int(&self) -> bool {
+        matches!(self, Self::Int)
+    }
+
+    /// Returns `true` if the type kind is [`Float`].
+    ///
+    /// [`Float`]: TypeKind::Float
+    #[must_use]
+    pub fn is_float(&self) -> bool {
+        matches!(self, Self::Float)
+    }
+
+    /// Returns `true` if the type kind is [`Bool`].
+    ///
+    /// [`Bool`]: TypeKind::Bool
+    #[must_use]
+    pub fn is_bool(&self) -> bool {
+        matches!(self, Self::Bool)
+    }
+
+    /// Returns `true` if the type kind is [`Char`].
+    ///
+    /// [`Char`]: TypeKind::Char
+    #[must_use]
+    pub fn is_char(&self) -> bool {
+        matches!(self, Self::Char)
+    }
+
+    /// Returns `true` if the type kind is [`String`].
+    ///
+    /// [`String`]: TypeKind::String
+    #[must_use]
+    pub fn is_string(&self) -> bool {
+        matches!(self, Self::String)
+    }
+
+    /// Returns `true` if the type kind is [`Timestamp`].
+    ///
+    /// [`Timestamp`]: TypeKind::Timestamp
+    #[must_use]
+    pub fn is_timestamp(&self) -> bool {
+        matches!(self, Self::Timestamp)
+    }
+
+    /// Returns `true` if the type kind is [`Array`].
+    ///
+    /// [`Array`]: TypeKind::Array
+    #[must_use]
+    pub fn is_array(&self) -> bool {
+        matches!(self, Self::Array(..))
+    }
+
+    #[must_use]
+    pub fn as_array(&self) -> Option<&Array> {
+        if let Self::Array(v) = self {
+            Some(v)
+        } else {
+            None
         }
     }
-}
 
-impl core::ops::Add for Type {
-    type Output = Type;
+    /// Returns `true` if the type kind is [`Object`].
+    ///
+    /// [`Object`]: TypeKind::Object
+    #[must_use]
+    pub fn is_object(&self) -> bool {
+        matches!(self, Self::Object(..))
+    }
 
-    fn add(self, rhs: Self) -> Self::Output {
-        match self {
-            Type::Union(mut u) => {
-                if !u.contains(&rhs) {
-                    u.push(rhs);
-                }
-                Type::Union(u)
-            }
-            t => {
-                if t == rhs {
-                    t
-                } else {
-                    Type::Union(vec![t, rhs])
-                }
-            }
+    #[must_use]
+    pub fn as_object(&self) -> Option<&Object> {
+        if let Self::Object(v) = self {
+            Some(v)
+        } else {
+            None
         }
+    }
+
+    /// Returns `true` if the type kind is [`Union`].
+    ///
+    /// [`Union`]: TypeKind::Union
+    #[must_use]
+    pub fn is_union(&self) -> bool {
+        matches!(self, Self::Union(..))
+    }
+
+    #[must_use]
+    pub fn as_union(&self) -> Option<&IndexSet<Type>> {
+        if let Self::Union(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Returns `true` if the type kind is [`Void`].
+    ///
+    /// [`Void`]: TypeKind::Void
+    #[must_use]
+    pub fn is_void(&self) -> bool {
+        matches!(self, Self::Void)
+    }
+
+    /// Returns `true` if the type kind is [`Fn`].
+    ///
+    /// [`Fn`]: TypeKind::Fn
+    #[must_use]
+    pub fn is_fn(&self) -> bool {
+        matches!(self, Self::Fn(..))
+    }
+
+    #[must_use]
+    pub fn as_fn(&self) -> Option<&Function> {
+        if let Self::Fn(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Returns `true` if the type kind is [`Alias`].
+    ///
+    /// [`Alias`]: TypeKind::Alias
+    #[must_use]
+    pub fn is_alias(&self) -> bool {
+        matches!(self, Self::Alias(..))
+    }
+
+    /// Returns `true` if the type kind is [`Unresolved`].
+    ///
+    /// [`Unresolved`]: TypeKind::Unresolved
+    #[must_use]
+    pub fn is_unresolved(&self) -> bool {
+        matches!(self, Self::Unresolved(..))
+    }
+
+    /// Returns `true` if the type kind is [`Never`].
+    ///
+    /// [`Never`]: TypeKind::Never
+    #[must_use]
+    pub fn is_never(&self) -> bool {
+        matches!(self, Self::Never)
+    }
+
+    /// Returns `true` if the type kind is [`Unknown`].
+    ///
+    /// [`Unknown`]: TypeKind::Unknown
+    #[must_use]
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown)
     }
 }
 
-impl<'a> core::ops::Add<&'a Type> for Type {
-    type Output = Type;
-
-    fn add(self, rhs: &'a Type) -> Self::Output {
-        match self {
-            Type::Union(mut u) => {
-                if !u.contains(rhs) {
-                    u.push(rhs.clone());
-                }
-                Type::Union(u)
-            }
-            t => {
-                if t == *rhs {
-                    t
-                } else {
-                    Type::Union(vec![t, rhs.clone()])
-                }
-            }
-        }
-    }
-}
-
-impl core::ops::AddAssign for Type {
-    fn add_assign(&mut self, rhs: Self) {
-        match self {
-            Type::Union(u) => {
-                if !u.contains(&rhs) {
-                    u.push(rhs);
-                }
-                *self = Type::Union(mem::take(u));
-            }
-            t => {
-                if t != &rhs {
-                    let this = mem::take(t);
-                    *t = Type::Union(vec![this, rhs]);
-                }
-            }
-        }
-    }
-}
-
-impl<'a> core::ops::AddAssign<&'a Type> for Type {
-    fn add_assign(&mut self, rhs: &'a Type) {
-        match self {
-            Type::Union(u) => {
-                if !u.contains(rhs) {
-                    u.push(rhs.clone());
-                }
-                *self = Type::Union(mem::take(u));
-            }
-            t => {
-                if t != rhs {
-                    let this = mem::take(t);
-                    *t = Type::Union(vec![this, rhs.clone()]);
-                }
-            }
-        }
-    }
-}
-
-impl Default for Type {
+impl Default for TypeKind {
     fn default() -> Self {
         Self::Unknown
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 pub struct Object {
-    pub fields: Vec<(String, Type)>,
+    pub fields: IndexMap<String, Type>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 pub struct Array {
-    pub item_types: Box<Type>,
-    pub known_items: Vec<Type>,
+    pub items: Type,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 pub struct Function {
     pub is_closure: bool,
     pub params: Vec<(String, Type)>,
-    pub ret: Box<Type>,
+    pub ret: Type,
 }

--- a/crates/rhai-hir/src/ty.rs
+++ b/crates/rhai-hir/src/ty.rs
@@ -82,7 +82,7 @@ impl core::fmt::Display for TypeFormatter<'_> {
                 let mut first = true;
                 for ty in tys {
                     if !first {
-                        f.write_str("| ")?;
+                        f.write_str(" | ")?;
                     }
                     first = false;
 

--- a/crates/rhai-hir/tests/definitions.rs
+++ b/crates/rhai-hir/tests/definitions.rs
@@ -24,7 +24,7 @@ fn print();
         &Parser::new(global_src).parse_def().into_syntax(),
     );
 
-    hir.resolve_references();
+    hir.resolve_all();
 
     assert!(hir.errors().is_empty());
 }
@@ -52,7 +52,7 @@ fn print();
         &Parser::new(global_src).parse_def().into_syntax(),
     );
 
-    hir.resolve_references();
+    hir.resolve_all();
 
     assert!(hir.errors().is_empty());
 }
@@ -80,7 +80,7 @@ fn print();
         &Parser::new(global_src).parse_def().into_syntax(),
     );
 
-    hir.resolve_references();
+    hir.resolve_all();
 
     assert!(hir.errors().is_empty());
 }
@@ -108,7 +108,7 @@ fn print();
         &Parser::new(global_src).parse_def().into_syntax(),
     );
 
-    hir.resolve_references();
+    hir.resolve_all();
 
     assert!(hir.errors().is_empty());
 }

--- a/crates/rhai-hir/tests/imports.rs
+++ b/crates/rhai-hir/tests/imports.rs
@@ -24,7 +24,7 @@ export const x = 1;
         &Parser::new(module_src).parse_script().into_syntax(),
     );
 
-    hir.resolve_references();
+    hir.resolve_all();
 
     assert!(hir.errors().is_empty());
 }
@@ -60,7 +60,7 @@ export const baz = 1;
         &Parser::new(bar_src).parse_script().into_syntax(),
     );
 
-    hir.resolve_references();
+    hir.resolve_all();
 
     assert!(hir.errors().is_empty());
 }
@@ -79,7 +79,7 @@ import "./foo.rhai" as foo;
         &Parser::new(root_src).parse_script().into_syntax(),
     );
 
-    hir.resolve_references();
+    hir.resolve_all();
 
     assert_eq!(hir.missing_modules().len(), 1);
 }

--- a/crates/rhai-hir/tests/smoke.rs
+++ b/crates/rhai-hir/tests/smoke.rs
@@ -155,12 +155,12 @@ fn add_and_remove_sources() {
             add(&mut hir, name, source);
         }
 
-        hir.resolve_references();
+        hir.resolve_all();
 
         for (name, _) in sources {
             remove(&mut hir, name);
         }
 
-        hir.resolve_references();
+        hir.resolve_all();
     }
 }

--- a/crates/rhai-hir/tests/visible_symbols.rs
+++ b/crates/rhai-hir/tests/visible_symbols.rs
@@ -18,7 +18,7 @@ let bar = 3;
 
     hir.add_source(&url, &Parser::new(&src).parse_def().into_syntax());
 
-    hir.resolve_references();
+    hir.resolve_all();
 
     assert!(hir
         .visible_symbols_from_offset(hir.source_by_url(&url).unwrap(), offset, false)
@@ -41,7 +41,7 @@ fn test_visible_import() {
 
     hir.add_source(&url, &Parser::new(&src).parse_def().into_syntax());
 
-    hir.resolve_references();
+    hir.resolve_all();
 
     assert!(hir
         .visible_symbols_from_offset(hir.source_by_url(&url).unwrap(), offset, false)

--- a/crates/rhai-lsp/src/handlers/document_symbols.rs
+++ b/crates/rhai-lsp/src/handlers/document_symbols.rs
@@ -8,7 +8,7 @@ use lsp_async_stub::{
 };
 use lsp_types::{DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, SymbolKind};
 use rhai_common::{environment::Environment, util::Normalize};
-use rhai_hir::{source::Source, symbol::ObjectSymbol, Hir, Scope, Type};
+use rhai_hir::{source::Source, symbol::ObjectSymbol, Hir, Scope};
 use rhai_rowan::{
     ast::{AstNode, ExprFn},
     syntax::{SyntaxElement, SyntaxKind, SyntaxNode},
@@ -103,7 +103,7 @@ fn collect_symbols(
                         .range(ident.text_range())
                         .unwrap_or_default()
                         .into_lsp(),
-                    detail: Some(signature_of(hir, root, symbol)),
+                    detail: Some(signature_of(hir, symbol)),
                     children: Some(collect_symbols(mapper, root, hir, f.scope, source)),
                     tags: None,
                 });
@@ -129,13 +129,7 @@ fn collect_symbols(
 
                 document_symbols.push(DocumentSymbol {
                     deprecated: None,
-                    kind: if matches!(&decl.ty, Type::Object(_)) {
-                        SymbolKind::OBJECT
-                    } else if decl.is_const {
-                        SymbolKind::CONSTANT
-                    } else {
-                        SymbolKind::VARIABLE
-                    },
+                    kind: SymbolKind::VARIABLE,
                     name: ident.to_string(),
                     range: mapper
                         .range(syntax.text_range())

--- a/crates/rhai-lsp/src/handlers/documents.rs
+++ b/crates/rhai-lsp/src/handlers/documents.rs
@@ -79,5 +79,5 @@ pub(crate) async fn update_document<E: Environment>(ctx: Context<World<E>>, uri:
     let mut ws = ctx.workspaces.write().await;
     let ws = ws.by_document_mut(&uri);
     ws.add_document(uri, text);
-    ws.hir.resolve_references();
+    ws.hir.resolve_all();
 }

--- a/crates/rhai-lsp/src/handlers/hover.rs
+++ b/crates/rhai-lsp/src/handlers/hover.rs
@@ -80,7 +80,7 @@ fn hover_for_symbol(
             Some(Hover {
                 contents: HoverContents::Markup(MarkupContent {
                     kind: MarkupKind::Markdown,
-                    value: documentation_for(hir, root, symbol, true),
+                    value: documentation_for(hir, symbol, true),
                 }),
                 range: highlight_range,
             })

--- a/crates/rhai-lsp/src/utils.rs
+++ b/crates/rhai-lsp/src/utils.rs
@@ -5,77 +5,42 @@ use futures::{
     future::{AbortHandle, Abortable},
     Future,
 };
-use rhai_hir::{Hir, Symbol, Type};
-use rhai_rowan::{
-    ast::{AstNode, ExprFn},
-    syntax::{SyntaxElement, SyntaxNode},
-};
+use rhai_hir::{symbol::SymbolKind, Hir, Symbol};
 
 use rhai_common::environment::Environment;
 
 /// Format signatures and definitions of symbols.
-pub fn signature_of(hir: &Hir, root: &SyntaxNode, symbol: Symbol) -> String {
-    if hir.symbol(symbol).is_none() {
-        return String::new();
-    }
-
+pub fn signature_of(hir: &Hir, symbol: Symbol) -> String {
     let sym_data = &hir[symbol];
 
     match &sym_data.kind {
-        rhai_hir::symbol::SymbolKind::Fn(f) => sym_data
-            .text_range()
-            .and_then(|range| {
-                if root.text_range().contains_range(range) {
-                    Some(root.covering_element(range))
+        SymbolKind::Decl(decl) => {
+            format!(
+                "{}{}: {}",
+                if decl.is_param {
+                    ""
+                } else if decl.is_const {
+                    "const "
                 } else {
-                    None
-                }
-            })
-            .and_then(SyntaxElement::into_node)
-            .and_then(ExprFn::cast)
-            .map(|expr_fn| {
-                if f.ty == Type::Unknown {
-                    // Format from syntax only.
-                    format!(
-                        "fn {ident}({params})",
-                        ident = &f.name,
-                        params = expr_fn
-                            .param_list()
-                            .map(|param_list| param_list
-                                .params()
-                                .map(|p| p.ident_token().map(|t| t.to_string()).unwrap_or_default())
-                                .collect::<Vec<String>>()
-                                .join(","))
-                            .unwrap_or_default()
-                    )
-                } else {
-                    format!("fn {ident}{sig:#}", ident = &f.name, sig = &f.ty)
-                }
-            })
-            .unwrap_or_default(),
-        rhai_hir::symbol::SymbolKind::Decl(d) => {
-            if d.is_param | d.is_pat {
-                format!("{name}: {ty:#}", name = d.name.clone(), ty = &d.ty)
-            } else {
-                format!(
-                    "{kw} {ident}: {ty:#}",
-                    ident = &d.name,
-                    kw = if d.is_const { "const" } else { "let" },
-                    ty = &d.ty
-                )
-            }
+                    "let "
+                },
+                decl.name,
+                sym_data.ty.fmt(hir)
+            )
         }
-        _ => String::new(),
+        _ => {
+            format!("{}", sym_data.ty.fmt(hir))
+        }
     }
 }
 
-pub fn documentation_for(hir: &Hir, root: &SyntaxNode, symbol: Symbol, signature: bool) -> String {
+pub fn documentation_for(hir: &Hir, symbol: Symbol, signature: bool) -> String {
     if let Some(m) = hir.target_module(symbol) {
         return hir[m].docs.clone();
     }
 
     let sig = if signature {
-        signature_of(hir, root, symbol).wrap_rhai_markdown()
+        signature_of(hir, symbol).wrap_rhai_markdown()
     } else {
         String::new()
     };

--- a/crates/rhai-rowan/src/ast/ext.rs
+++ b/crates/rhai-rowan/src/ast/ext.rs
@@ -7,7 +7,7 @@ use rowan::NodeOrToken;
 
 use super::{
     AstNode, DefOpPrecedence, Expr, LitStrTemplate, LitStrTemplateInterpolation, ObjectField,
-    Param, ParamList, Stmt, SwitchArm, SwitchArmCondition, TypedParam,
+    Param, ParamList, Stmt, SwitchArm, SwitchArmCondition, Type, TypedParam,
 };
 use super::{ExprBlock, ExprIf, T};
 use crate::syntax::{SyntaxElement, SyntaxKind, SyntaxToken};
@@ -353,11 +353,20 @@ impl super::DefFn {
             })
             .nth(if self.has_kw_get() { 1 } else { 0 })
     }
+
+    #[must_use]
+    pub fn ret_ty(&self) -> Option<Type> {
+        self.syntax().children().find_map(Type::cast)
+    }
 }
 
 impl super::DefOp {
     pub fn precedence(&self) -> Option<DefOpPrecedence> {
         self.syntax().children().find_map(AstNode::cast)
+    }
+
+    pub fn ret_ty(&self) -> Option<Type> {
+        self.syntax().children().find_map(Type::cast)
     }
 }
 
@@ -409,6 +418,24 @@ impl super::DefModule {
             }
             t.into_token()
         })
+    }
+}
+
+impl super::DefLet {
+    pub fn ty(&self) -> Option<Type> {
+        self.syntax().children().find_map(Type::cast)
+    }
+}
+
+impl super::DefConst {
+    pub fn ty(&self) -> Option<Type> {
+        self.syntax().children().find_map(Type::cast)
+    }
+}
+
+impl super::TypeList {
+    pub fn types(&self) -> impl Iterator<Item = Type> {
+        self.syntax().children().filter_map(Type::cast)
     }
 }
 

--- a/crates/rhai-rowan/src/ast/ext.rs
+++ b/crates/rhai-rowan/src/ast/ext.rs
@@ -421,6 +421,22 @@ impl super::DefModule {
     }
 }
 
+impl super::DefType {
+    pub fn ty(&self) -> Option<Type> {
+        self.syntax().children().find_map(Type::cast)
+    }
+
+    #[must_use]
+    pub fn op_spread(&self) -> Option<SyntaxToken> {
+        self.syntax().children_with_tokens().find_map(|t| {
+            if t.kind() != T!["..."] {
+                return None;
+            }
+            t.into_token()
+        })
+    }
+}
+
 impl super::DefLet {
     pub fn ty(&self) -> Option<Type> {
         self.syntax().children().find_map(Type::cast)

--- a/crates/rhai-rowan/src/ast/ext.rs
+++ b/crates/rhai-rowan/src/ast/ext.rs
@@ -6,8 +6,8 @@
 use rowan::NodeOrToken;
 
 use super::{
-    AstNode, DefOpPrecedence, Expr, LitStrTemplate, LitStrTemplateInterpolation, ObjectField,
-    Param, ParamList, Stmt, SwitchArm, SwitchArmCondition, Type, TypedParam,
+    AstNode, DefOpPrecedence, Expr, Lit, LitStrTemplate, LitStrTemplateInterpolation, ObjectField,
+    Param, ParamList, Stmt, SwitchArm, SwitchArmCondition, Type, TypeObjectField, TypedParam,
 };
 use super::{ExprBlock, ExprIf, T};
 use crate::syntax::{SyntaxElement, SyntaxKind, SyntaxToken};
@@ -434,6 +434,35 @@ impl super::DefConst {
 }
 
 impl super::TypeList {
+    pub fn types(&self) -> impl Iterator<Item = Type> {
+        self.syntax().children().filter_map(Type::cast)
+    }
+}
+
+impl super::TypeObject {
+    pub fn fields(&self) -> impl Iterator<Item = TypeObjectField> {
+        self.syntax().children().filter_map(TypeObjectField::cast)
+    }
+}
+
+impl super::TypeObjectField {
+    #[must_use]
+    pub fn name_ident(&self) -> Option<SyntaxToken> {
+        self.syntax().children_with_tokens().find_map(|t| {
+            if t.kind() != T!["ident"] {
+                return None;
+            }
+            t.into_token()
+        })
+    }
+
+    #[must_use]
+    pub fn name_lit(&self) -> Option<Lit> {
+        self.syntax().children().find_map(Lit::cast)
+    }
+}
+
+impl super::TypeTuple {
     pub fn types(&self) -> impl Iterator<Item = Type> {
         self.syntax().children().filter_map(Type::cast)
     }

--- a/crates/rhai-rowan/src/ast/rhai.ungram
+++ b/crates/rhai-rowan/src/ast/rhai.ungram
@@ -256,7 +256,7 @@ DefOp =
       | '.'
     )
   )
-  TypeList ('->' ty:Type)?
+  TypeList ('->' ret_ty:Type)?
   precedence:DefOpPrecedence?
 
 DefOpPrecedence =
@@ -272,7 +272,7 @@ DefFn =
   __kw_get:'ident'?
   __name:'ident'
   TypedParamList
-  ('->' ty:Type)?
+  ('->' ret_ty:Type)?
 
 Type =
   TypeIdent

--- a/crates/rhai-rowan/src/ast/rhai.ungram
+++ b/crates/rhai-rowan/src/ast/rhai.ungram
@@ -265,7 +265,7 @@ DefOpPrecedence =
   binding_powers:('lit_int' (',' 'lit_int')* ','?)?
   ')'
 
-DefType = ty_token:'ident' 'ident' '=' ty:Type
+DefType = ty_token:'ident' 'ident' '=' (ty:Type | '...')
 
 DefFn =
   'fn'

--- a/crates/rhai-rowan/src/parser/parsers/def.rs
+++ b/crates/rhai-rowan/src/parser/parsers/def.rs
@@ -353,7 +353,13 @@ pub fn parse_def_type(ctx: &mut Context) {
     expect_token!(ctx in node, T!["ident"]);
     expect_token!(ctx in node, T!["="]);
 
-    super::ty::parse_type(ctx);
+    let token = require_token!(ctx in node);
+
+    if token == T!["..."] {
+        ctx.eat();
+    } else {
+        super::ty::parse_type(ctx);
+    }
 
     ctx.finish_node();
 }

--- a/crates/rhai-rowan/src/query/mod.rs
+++ b/crates/rhai-rowan/src/query/mod.rs
@@ -64,6 +64,28 @@ impl Query {
     }
 
     #[must_use]
+    pub fn ident(&self) -> Option<SyntaxToken> {
+        self.before
+            .as_ref()
+            .and_then(|t| {
+                if t.syntax.kind() == IDENT {
+                    Some(t.syntax.clone())
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                self.after.as_ref().and_then(|t| {
+                    if t.syntax.kind() == IDENT {
+                        Some(t.syntax.clone())
+                    } else {
+                        None
+                    }
+                })
+            })
+    }
+
+    #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn binary_op_ident(&self) -> Option<SyntaxToken> {
         self.binary_expr().and_then(|expr| {


### PR DESCRIPTION
closes #16, and closes #5 

- Types are first-class in the HIR, and can be referenced just like symbols/scopes.
- Every symbol has a type attached to it defaulting to unknown (`?`).
- Types are contagious, as in references, assignments carry type information forward.
- Semantic tokens are now used for types like functions.
- Object fields are now subject to completions as well based on the types of the objects.
- Function (and other) signatures are now type-based and do not rely on the syntax-tree anymore, as long as types are known, signatures are always known no matter what document contains the item definition.
- There are no generics, and I hope they won't be necessary, or only in limited ways.

### Type Inference

There is a very basic one-way type inference algorithm involved, types are known for literals and from items with type annotations, the rest of the types are all deducted from these.

In the example below the type of `foo` is the union of the types of `bar` and `baz`, the type-checker will not attempt to reverse the logic, even if `foo` has previously known types, neither `bar` nor `baz` will be deducted from it.

```rhai
foo = if true {
  bar
} else {
  baz
};
```

The operators defined in definition files will also determine the type of binary (and unary) expressions.

The current goal of this type system is enhancing DX rather than enforcing correctness, as currently Rhai won't have tools for overriding inferred types and providing type annotations inline anytime soon.

[Peek 2022-08-07 19-27.webm](https://user-images.githubusercontent.com/25967296/183303524-4c47a5ec-b7a7-42f9-8af7-7ed25072ce20.webm)

[Peek 2022-08-07 19-31.webm](https://user-images.githubusercontent.com/25967296/183303532-f596b70d-cefd-4772-9d6a-04c5248a8646.webm)

