### PR TITLE
rhai fmt

### DIFF
--- a/crates/rhai-cli/Cargo.toml
+++ b/crates/rhai-cli/Cargo.toml
@@ -13,6 +13,7 @@ rhai = "1.8.0"
 anyhow = "1.0.59"
 async-ctrlc = { version = "1.2.0", features = ["stream"] }
 tracing = "0.1.36"
+rhai-fmt = { version = "0.1.0", path = "../rhai-fmt" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 atty = "0.2.14"

--- a/crates/rhai-fmt/Cargo.toml
+++ b/crates/rhai-fmt/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rhai-fmt"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+rhai-rowan = { version = "0.1.0", path = "../rhai-rowan" }
+rowan = "0.15.8"
+serde = { version = "1.0.144", features = ["derive"] }
+tracing = "0.1.36"
+
+[dev-dependencies]
+criterion = "0.3.6"
+pretty_assertions = "1.3.0"
+tracing-subscriber = "0.3.15"
+
+[[bench]]
+name = "fmt"
+harness = false

--- a/crates/rhai-fmt/benches/fmt.rs
+++ b/crates/rhai-fmt/benches/fmt.rs
@@ -1,0 +1,47 @@
+use std::{ffi::OsStr, fs, path::Path};
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use rhai_fmt::{format_source, format_syntax};
+
+fn mega_script() -> String {
+    let root_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("testdata")
+        .join("valid");
+    let scripts = fs::read_dir(&root_path).unwrap();
+
+    let mut script = String::new();
+
+    for entry in scripts {
+        let entry = entry.unwrap();
+
+        if entry.path().extension() == Some(OsStr::new("rhai")) {
+            script += &fs::read_to_string(root_path.join(entry.path())).unwrap();
+            script += ";\n";
+        }
+    }
+
+    script
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let source = mega_script();
+
+    let parsed = rhai_rowan::parser::Parser::new(&source)
+        .parse_script()
+        .into_syntax();
+
+    let mut group = c.benchmark_group("fmt-throughput");
+    group.throughput(Throughput::Bytes(source.len() as u64));
+    group.bench_function("fmt all", |b| {
+        b.iter(|| format_source(black_box(&source), Default::default()))
+    });
+    group.bench_function("fmt parsed", |b| {
+        b.iter(|| format_syntax(black_box(parsed.clone()), Default::default()))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/crates/rhai-fmt/src/algorithm.rs
+++ b/crates/rhai-fmt/src/algorithm.rs
@@ -1,0 +1,378 @@
+#![allow(dead_code)]
+use crate::{ring::RingBuffer, Options};
+use std::{
+    cmp,
+    collections::VecDeque,
+    io::{self, Write},
+    iter,
+};
+
+const MIN_SPACE: isize = 60;
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum Breaks {
+    Consistent,
+    Inconsistent,
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct BreakToken {
+    pub offset: isize,
+    pub blank_space: usize,
+    pub pre_break: Option<char>,
+    pub post_break: Option<char>,
+    pub no_break: Option<char>,
+    pub if_nonempty: bool,
+    pub never_break: bool,
+}
+
+#[derive(Clone, Copy)]
+pub struct BeginToken {
+    pub offset: isize,
+    pub breaks: Breaks,
+}
+
+#[derive(Clone)]
+pub enum Token {
+    String(&'static str),
+    Break(BreakToken),
+    Begin(BeginToken),
+    End,
+}
+
+#[derive(Copy, Clone)]
+enum PrintFrame {
+    Fits(Breaks),
+    Broken(usize, Breaks),
+}
+
+pub const SIZE_INFINITY: isize = 0xffff;
+
+pub struct Formatter<W: Write> {
+    pub(crate) options: Options,
+    pub(crate) out: W,
+    // Number of spaces left on line
+    space: isize,
+    // Ring-buffer of tokens and calculated sizes
+    buf: RingBuffer<BufEntry>,
+    // Total size of tokens already printed
+    left_total: isize,
+    // Total size of tokens enqueued, including printed and not yet printed
+    right_total: isize,
+    // Holds the ring-buffer index of the Begin that started the current block,
+    // possibly with the most recent Break after that Begin (if there is any) on
+    // top of it. Values are pushed and popped on the back of the queue using it
+    // like stack, and elsewhere old values are popped from the front of the
+    // queue as they become irrelevant due to the primary ring-buffer advancing.
+    scan_stack: VecDeque<usize>,
+    // Stack of blocks-in-progress being flushed by print
+    print_stack: Vec<PrintFrame>,
+    // Level of indentation of current line
+    indent: usize,
+    // Buffered indentation to avoid writing trailing whitespace
+    pending_indentation: usize,
+    // Spaces are separate from indentation,
+    // as indentation can be tabs or any number of
+    // spaces.
+    pending_spaces: usize,
+}
+
+#[derive(Clone)]
+struct BufEntry {
+    token: Token,
+    size: isize,
+}
+
+impl<W: Write> Formatter<W> {
+    pub fn new(out: W) -> Self {
+        Self::new_with_options(out, Options::default())
+    }
+
+    pub fn new_with_options(out: W, options: Options) -> Self {
+        Formatter {
+            out,
+            space: options.max_width as _,
+            options,
+            buf: RingBuffer::new(),
+            left_total: 0,
+            right_total: 0,
+            scan_stack: VecDeque::new(),
+            print_stack: Vec::new(),
+            indent: 0,
+            pending_indentation: 0,
+            pending_spaces: 0,
+        }
+    }
+
+    pub(crate) fn eof(mut self) -> io::Result<()> {
+        if !self.scan_stack.is_empty() {
+            self.check_stack(0);
+            self.advance_left()?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn scan_begin(&mut self, token: BeginToken) {
+        if self.scan_stack.is_empty() {
+            self.left_total = 1;
+            self.right_total = 1;
+            self.buf.clear();
+        }
+        let right = self.buf.push(BufEntry {
+            token: Token::Begin(token),
+            size: -self.right_total,
+        });
+        self.scan_stack.push_back(right);
+    }
+
+    pub(crate) fn scan_end(&mut self) {
+        if self.scan_stack.is_empty() {
+            self.print_end();
+        } else {
+            if !self.buf.is_empty() {
+                if let Token::Break(break_token) = self.buf.last().token {
+                    if self.buf.len() >= 2 {
+                        if let Token::Begin(_) = self.buf.second_last().token {
+                            self.buf.pop_last();
+                            self.buf.pop_last();
+                            self.scan_stack.pop_back();
+                            self.scan_stack.pop_back();
+                            self.right_total -= break_token.blank_space as isize;
+                            return;
+                        }
+                    }
+                    if break_token.if_nonempty {
+                        self.buf.pop_last();
+                        self.scan_stack.pop_back();
+                        self.right_total -= break_token.blank_space as isize;
+                    }
+                }
+            }
+            let right = self.buf.push(BufEntry {
+                token: Token::End,
+                size: -1,
+            });
+            self.scan_stack.push_back(right);
+        }
+    }
+
+    pub(crate) fn scan_break(&mut self, token: BreakToken) {
+        if self.scan_stack.is_empty() {
+            self.left_total = 1;
+            self.right_total = 1;
+            self.buf.clear();
+        } else {
+            self.check_stack(0);
+        }
+        let right = self.buf.push(BufEntry {
+            token: Token::Break(token),
+            size: -self.right_total,
+        });
+        self.scan_stack.push_back(right);
+        self.right_total += token.blank_space as isize;
+    }
+
+    pub(crate) fn scan_string(&mut self, string: &'static str) -> io::Result<()> {
+        if self.scan_stack.is_empty() {
+            self.print_string(string)?;
+        } else {
+            let len = string.len() as isize;
+            self.buf.push(BufEntry {
+                token: Token::String(string),
+                size: len,
+            });
+            self.right_total += len;
+            self.check_stream()?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn offset(&mut self, offset: isize) {
+        match &mut self.buf.last_mut().token {
+            Token::Break(token) => token.offset += offset,
+            Token::Begin(_) => {}
+            Token::String(_) | Token::End => unreachable!(),
+        }
+    }
+
+    pub(crate) fn end_with_max_width(&mut self, max: isize) {
+        let mut depth = 1;
+        for &index in self.scan_stack.iter().rev() {
+            let entry = &self.buf[index];
+            match entry.token {
+                Token::Begin(_) => {
+                    depth -= 1;
+                    if depth == 0 {
+                        if entry.size < 0 {
+                            let actual_width = entry.size + self.right_total;
+                            if actual_width > max {
+                                self.buf.push(BufEntry {
+                                    token: Token::String(""),
+                                    size: SIZE_INFINITY,
+                                });
+                                self.right_total += SIZE_INFINITY;
+                            }
+                        }
+                        break;
+                    }
+                }
+                Token::End => depth += 1,
+                Token::Break(_) => {}
+                Token::String(_) => unreachable!(),
+            }
+        }
+        self.scan_end();
+    }
+
+    fn check_stream(&mut self) -> io::Result<()> {
+        while self.right_total - self.left_total > self.space {
+            if *self.scan_stack.front().unwrap() == self.buf.index_of_first() {
+                self.scan_stack.pop_front().unwrap();
+                self.buf.first_mut().size = SIZE_INFINITY;
+            }
+
+            self.advance_left()?;
+
+            if self.buf.is_empty() {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn advance_left(&mut self) -> io::Result<()> {
+        while self.buf.first().size >= 0 {
+            let left = self.buf.pop_first();
+
+            match left.token {
+                Token::String(string) => {
+                    self.left_total += left.size;
+                    self.print_string(string)?;
+                }
+                Token::Break(token) => {
+                    self.left_total += token.blank_space as isize;
+                    self.print_break(token, left.size)?;
+                }
+                Token::Begin(token) => self.print_begin(token, left.size),
+                Token::End => self.print_end(),
+            }
+
+            if self.buf.is_empty() {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_stack(&mut self, mut depth: usize) {
+        while let Some(&index) = self.scan_stack.back() {
+            let mut entry = &mut self.buf[index];
+            match entry.token {
+                Token::Begin(_) => {
+                    if depth == 0 {
+                        break;
+                    }
+                    self.scan_stack.pop_back().unwrap();
+                    entry.size += self.right_total;
+                    depth -= 1;
+                }
+                Token::End => {
+                    self.scan_stack.pop_back().unwrap();
+                    entry.size = 1;
+                    depth += 1;
+                }
+                Token::Break(_) => {
+                    self.scan_stack.pop_back().unwrap();
+                    entry.size += self.right_total;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                Token::String(_) => unreachable!(),
+            }
+        }
+    }
+
+    fn get_top(&self) -> PrintFrame {
+        const OUTER: PrintFrame = PrintFrame::Broken(0, Breaks::Inconsistent);
+        self.print_stack.last().map_or(OUTER, PrintFrame::clone)
+    }
+
+    fn print_begin(&mut self, token: BeginToken, size: isize) {
+        if size > self.space {
+            self.print_stack
+                .push(PrintFrame::Broken(self.indent, token.breaks));
+            self.indent = usize::try_from(self.indent as isize + token.offset).unwrap();
+        } else {
+            self.print_stack.push(PrintFrame::Fits(token.breaks));
+        }
+    }
+
+    fn print_end(&mut self) {
+        match self.print_stack.pop().unwrap() {
+            PrintFrame::Broken(indent, breaks) => {
+                self.indent = indent;
+                breaks
+            }
+            PrintFrame::Fits(breaks) => breaks,
+        };
+    }
+
+    fn print_break(&mut self, token: BreakToken, size: isize) -> io::Result<()> {
+        let fits = token.never_break
+            || match self.get_top() {
+                PrintFrame::Fits(..) => true,
+                PrintFrame::Broken(.., Breaks::Consistent) => false,
+                PrintFrame::Broken(.., Breaks::Inconsistent) => size <= self.space,
+            };
+        if fits {
+            self.pending_spaces += token.blank_space;
+            self.space -= token.blank_space as isize;
+            if let Some(no_break) = token.no_break {
+                self.out.write_all(&[no_break as _])?;
+                self.space -= no_break.len_utf8() as isize;
+            }
+        } else {
+            if let Some(pre_break) = token.pre_break {
+                self.print_indent()?;
+                self.out.write_all(&[pre_break as _])?;
+            }
+            self.out.write_all(b"\n")?;
+            let indent = self.indent as isize + token.offset;
+            self.pending_indentation = usize::try_from(indent).unwrap();
+            self.space = cmp::max(self.options.max_width as isize - indent, MIN_SPACE);
+            if let Some(post_break) = token.post_break {
+                self.print_indent()?;
+                self.out.write_all(&[post_break as _])?;
+                self.space -= post_break.len_utf8() as isize;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn print_string(&mut self, string: &'static str) -> io::Result<()> {
+        self.print_indent()?;
+        self.out.write_all(string.as_bytes())?;
+        self.space -= string.len() as isize;
+        Ok(())
+    }
+
+    fn print_indent(&mut self) -> io::Result<()> {
+        for _ in 0..self.pending_indentation {
+            self.out.write_all(self.options.indent_string.as_bytes())?;
+        }
+
+        for sp in iter::repeat(' ').take(self.pending_spaces) {
+            self.out.write_all(&[sp as _])?;
+        }
+
+        self.pending_indentation = 0;
+        self.pending_spaces = 0;
+        Ok(())
+    }
+}

--- a/crates/rhai-fmt/src/comments.rs
+++ b/crates/rhai-fmt/src/comments.rs
@@ -1,0 +1,182 @@
+//! Comments unfortunately require some special handling.
+//!
+//! Currently we take the following comments into account:
+//!
+//! ```rhai
+//! {
+//!   // 1. leading child comments
+//!   
+//!   // 1. with whitespace in between
+//!
+//!   let a = "foo"; // 2. comment between but still same line
+//!
+//!   // 2. standalone comments between nodes with white space
+//!
+//!   let b = "bar"; // 3. comments after last node
+//!
+//!   // 3. trailing standalone comments
+//! }
+//! ```
+
+#![allow(dead_code)]
+use rhai_rowan::syntax::{SyntaxElement, SyntaxKind::*, SyntaxNode};
+use rowan::Direction;
+
+use crate::{
+    algorithm::Formatter,
+    util::{break_count, ScopedStatic},
+};
+use std::io::{self, Write};
+
+impl<W: Write> Formatter<W> {
+    /// Comments in position 1.
+    ///
+    /// Returns true if ended with a hardbreak.
+    pub(crate) fn leading_comments_in(&mut self, node: &SyntaxNode) -> io::Result<bool> {
+        let ws_and_comments = node
+            .children_with_tokens()
+            .skip_while(|e| {
+                e.as_token().is_some()
+                    && !matches!(e.kind(), WHITESPACE | COMMENT_BLOCK | COMMENT_LINE)
+            })
+            .take_while(|e| matches!(e.kind(), WHITESPACE | COMMENT_BLOCK | COMMENT_LINE))
+            .filter_map(SyntaxElement::into_token)
+            .collect::<Vec<_>>();
+
+        let mut hardbreak_last = false;
+        for ws_or_comment in ws_and_comments {
+            match ws_or_comment.kind() {
+                COMMENT_BLOCK | COMMENT_LINE => {
+                    self.word(ws_or_comment.static_text().trim_end())?;
+                    hardbreak_last = false;
+                }
+                WHITESPACE => {
+                    let breaks = break_count(&ws_or_comment);
+                    self.hardbreaks(breaks);
+                    if breaks > 0 {
+                        hardbreak_last = true;
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        Ok(hardbreak_last)
+    }
+
+    /// Comments in position 2.
+    pub(crate) fn comments_before_or_hardbreak(&mut self, node: &SyntaxNode) -> io::Result<()> {
+        let mut ws_and_comments = node
+            .siblings_with_tokens(Direction::Prev)
+            .skip(1)
+            .take_while(|e| matches!(e.kind(), WHITESPACE | COMMENT_BLOCK | COMMENT_LINE))
+            .filter_map(SyntaxElement::into_token)
+            .collect::<Vec<_>>();
+
+        ws_and_comments.reverse();
+
+        let mut hardbreak_last = false;
+
+        let comment_at_p1 = ws_and_comments
+            .get(1)
+            .map(|e| e.kind() != WHITESPACE)
+            .unwrap_or(false);
+
+        for (idx, ws_or_comment) in ws_and_comments.into_iter().enumerate() {
+            match ws_or_comment.kind() {
+                COMMENT_BLOCK | COMMENT_LINE => {
+                    if idx == 0 {
+                        self.nbsp()?;
+                    }
+                    self.word(ws_or_comment.static_text().trim_end())?;
+                    hardbreak_last = false;
+                }
+                WHITESPACE => {
+                    let breaks = break_count(&ws_or_comment);
+                    if idx == 0 && breaks == 0 && comment_at_p1 {
+                        self.nbsp()?;
+                    } else if breaks > 0 {
+                        hardbreak_last = true;
+                        self.hardbreaks(breaks)
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        if !hardbreak_last {
+            self.hardbreak();
+        }
+
+        Ok(())
+    }
+
+    /// Comments in position 3.
+    ///
+    /// Always ends with a hardbreak unless
+    /// specified **and** the last comment is a line comment.
+    pub(crate) fn trailing_comments_after(
+        &mut self,
+        node: &SyntaxNode,
+        hardbreak_after_last_line: bool,
+    ) -> io::Result<()> {
+        let mut ws_and_comments = node
+            .siblings_with_tokens(Direction::Next)
+            .skip(1)
+            .take_while(|e| matches!(e.kind(), WHITESPACE | COMMENT_BLOCK | COMMENT_LINE))
+            .filter_map(SyntaxElement::into_token)
+            .enumerate()
+            .collect::<Vec<_>>();
+
+        let last_comment_position = ws_and_comments.iter().rev().find_map(|(idx, c)| {
+            if c.kind() != WHITESPACE {
+                Some(*idx)
+            } else {
+                None
+            }
+        });
+
+        match last_comment_position {
+            Some(p) => {
+                ws_and_comments.truncate(p + 1);
+            }
+            None => return Ok(()),
+        }
+
+        let comment_at_p1 = ws_and_comments
+            .get(1)
+            .map(|(_, e)| e.kind() != WHITESPACE)
+            .unwrap_or(false);
+
+        let len = ws_and_comments.len();
+
+        for (idx, ws_or_comment) in ws_and_comments {
+            match ws_or_comment.kind() {
+                COMMENT_BLOCK | COMMENT_LINE => {
+                    if idx == 0 {
+                        self.nbsp()?;
+                    }
+                    self.word(ws_or_comment.static_text().trim_end())?;
+
+                    if hardbreak_after_last_line
+                        && idx + 1 == len
+                        && matches!(ws_or_comment.kind(), COMMENT_LINE)
+                    {
+                        self.hardbreak();
+                    }
+                }
+                WHITESPACE => {
+                    let breaks = break_count(&ws_or_comment);
+                    if idx == 0 && breaks == 0 && comment_at_p1 {
+                        self.nbsp()?;
+                    } else if breaks != 0 {
+                        self.hardbreaks(breaks);
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/rhai-fmt/src/cst.rs
+++ b/crates/rhai-fmt/src/cst.rs
@@ -1,0 +1,75 @@
+use std::io::{self, Write};
+
+use rhai_rowan::{
+    ast::AstNode,
+    syntax::{SyntaxElement, SyntaxKind::*},
+};
+
+use crate::{algorithm::Formatter, util::ScopedStatic};
+
+impl<S: Write> Formatter<S> {
+    #[allow(clippy::missing_panics_doc)]
+    pub fn format(mut self, element: impl Into<SyntaxElement>) -> io::Result<()> {
+        self.fmt_element(element.into())?;
+        self.eof()
+    }
+
+    fn fmt_element(&mut self, element: SyntaxElement) -> io::Result<()> {
+        let node = match element {
+            rowan::NodeOrToken::Node(n) => n,
+            rowan::NodeOrToken::Token(t)
+                if matches!(
+                    t.kind(),
+                    COMMENT_BLOCK | COMMENT_LINE | COMMENT_BLOCK_DOC | COMMENT_LINE_DOC | SHEBANG
+                ) =>
+            {
+                self.word(t.static_text())?;
+                self.hardbreak();
+                return Ok(());
+            }
+            rowan::NodeOrToken::Token(_) => return Ok(()),
+        };
+
+        match node.kind() {
+            RHAI => self.fmt_rhai(AstNode::cast(node).unwrap())?,
+            STMT => self.fmt_stmt(AstNode::cast(node).unwrap())?,
+            ITEM => self.fmt_item(AstNode::cast(node).unwrap())?,
+            DOC => self.fmt_doc(AstNode::cast(node).unwrap())?,
+            EXPR => self.fmt_expr(AstNode::cast(node).unwrap())?,
+            EXPR_IDENT => self.fmt_expr_ident(AstNode::cast(node).unwrap())?,
+            EXPR_PATH => self.fmt_expr_path(AstNode::cast(node).unwrap())?,
+            EXPR_LIT => self.fmt_expr_lit(AstNode::cast(node).unwrap())?,
+            EXPR_LET => self.fmt_expr_let(AstNode::cast(node).unwrap())?,
+            EXPR_CONST => self.fmt_expr_const(AstNode::cast(node).unwrap())?,
+            EXPR_BLOCK => self.fmt_expr_block(AstNode::cast(node).unwrap(), false)?,
+            EXPR_UNARY => self.fmt_expr_unary(AstNode::cast(node).unwrap())?,
+            EXPR_BINARY => self.fmt_expr_binary(AstNode::cast(node).unwrap())?,
+            EXPR_PAREN => self.fmt_expr_paren(AstNode::cast(node).unwrap())?,
+            EXPR_ARRAY => self.fmt_expr_array(AstNode::cast(node).unwrap())?,
+            EXPR_INDEX => self.fmt_expr_index(AstNode::cast(node).unwrap())?,
+            EXPR_OBJECT => self.fmt_expr_object(AstNode::cast(node).unwrap())?,
+            EXPR_CALL => self.fmt_expr_call(AstNode::cast(node).unwrap())?,
+            EXPR_CLOSURE => self.fmt_expr_closure(AstNode::cast(node).unwrap())?,
+            EXPR_IF => self.fmt_expr_if(AstNode::cast(node).unwrap())?,
+            EXPR_LOOP => self.fmt_expr_loop(AstNode::cast(node).unwrap())?,
+            EXPR_FOR => self.fmt_expr_for(AstNode::cast(node).unwrap())?,
+            EXPR_WHILE => self.fmt_expr_while(AstNode::cast(node).unwrap())?,
+            EXPR_BREAK => self.fmt_expr_break(AstNode::cast(node).unwrap())?,
+            EXPR_CONTINUE => self.fmt_expr_continue(AstNode::cast(node).unwrap())?,
+            EXPR_SWITCH => self.fmt_expr_switch(AstNode::cast(node).unwrap())?,
+            EXPR_RETURN => self.fmt_expr_return(AstNode::cast(node).unwrap())?,
+            EXPR_FN => self.fmt_expr_fn(AstNode::cast(node).unwrap())?,
+            EXPR_EXPORT => self.fmt_expr_export(AstNode::cast(node).unwrap())?,
+            EXPR_IMPORT => self.fmt_expr_import(AstNode::cast(node).unwrap())?,
+            EXPR_TRY => self.fmt_expr_try(AstNode::cast(node).unwrap())?,
+            EXPR_THROW => self.fmt_expr_throw(AstNode::cast(node).unwrap())?,
+            kind => {
+                // TODO: def and type formatting
+                self.out.write_all(node.to_string().as_bytes())?;
+                tracing::warn!(?kind, "unformatted syntax node");
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/rhai-fmt/src/expr.rs
+++ b/crates/rhai-fmt/src/expr.rs
@@ -1,0 +1,779 @@
+use std::io::{self, Write};
+
+use rhai_rowan::{
+    ast::{AstNode, ExportTarget, Expr, ExprBlock, ExprConst, ExprContinue, ExprIf, ExprLet},
+    syntax::{
+        SyntaxElement,
+        SyntaxKind::{self, *},
+    },
+    T,
+};
+
+use crate::{
+    algorithm::Formatter,
+    source::needs_stmt_separator,
+    util::{break_count, ScopedStatic},
+};
+
+impl<S: Write> Formatter<S> {
+    pub(crate) fn fmt_expr(&mut self, expr: Expr) -> io::Result<()> {
+        let syntax = expr.syntax();
+
+        match expr {
+            Expr::Ident(expr) => {
+                self.fmt_expr_ident(expr)?;
+            }
+            Expr::Path(expr) => {
+                self.fmt_expr_path(expr)?;
+            }
+            Expr::Lit(expr) => {
+                self.fmt_expr_lit(expr)?;
+            }
+            Expr::Let(expr) => {
+                self.fmt_expr_let(expr)?;
+            }
+            Expr::Const(expr) => {
+                self.fmt_expr_const(expr)?;
+            }
+            Expr::Block(expr) => {
+                self.fmt_expr_block(expr, false)?;
+            }
+            Expr::Unary(expr) => {
+                self.fmt_expr_unary(expr)?;
+            }
+            Expr::Binary(expr) => {
+                self.fmt_expr_binary(expr)?;
+            }
+            Expr::Paren(expr) => {
+                self.fmt_expr_paren(expr)?;
+            }
+            Expr::Array(expr) => {
+                self.fmt_expr_array(expr)?;
+            }
+            Expr::Index(expr) => {
+                self.fmt_expr_index(expr)?;
+            }
+            Expr::Object(expr) => {
+                self.fmt_expr_object(expr)?;
+            }
+            Expr::Call(expr) => {
+                self.fmt_expr_call(expr)?;
+            }
+            Expr::Closure(expr) => {
+                self.fmt_expr_closure(expr)?;
+            }
+            Expr::If(expr) => {
+                self.fmt_expr_if(expr)?;
+            }
+            Expr::Loop(expr) => {
+                self.fmt_expr_loop(expr)?;
+            }
+            Expr::For(expr) => {
+                self.fmt_expr_for(expr)?;
+            }
+            Expr::While(expr) => {
+                self.fmt_expr_while(expr)?;
+            }
+            Expr::Break(expr) => {
+                self.fmt_expr_break(expr)?;
+            }
+            Expr::Continue(expr) => {
+                self.fmt_expr_continue(expr)?;
+            }
+            Expr::Switch(expr) => {
+                self.fmt_expr_switch(expr)?;
+            }
+            Expr::Return(expr) => {
+                self.fmt_expr_return(expr)?;
+            }
+            Expr::Fn(expr) => {
+                self.fmt_expr_fn(expr)?;
+            }
+            Expr::Export(expr) => {
+                self.fmt_expr_export(expr)?;
+            }
+            Expr::Import(expr) => {
+                self.fmt_expr_import(expr)?;
+            }
+            Expr::Try(expr) => {
+                self.fmt_expr_try(expr)?;
+            }
+            Expr::Throw(expr) => {
+                self.fmt_expr_throw(expr)?;
+            }
+        }
+
+        if let Some(child) = syntax.first_child() {
+            self.trailing_comments_after(&child, true)?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_throw(
+        &mut self,
+        expr: rhai_rowan::ast::ExprThrow,
+    ) -> Result<(), io::Error> {
+        self.word("throw")?;
+        if let Some(expr) = expr.expr() {
+            self.nbsp()?;
+            self.fmt_expr(expr)?;
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_try(&mut self, expr: rhai_rowan::ast::ExprTry) -> Result<(), io::Error> {
+        self.word("try ")?;
+        if let Some(body) = expr.try_block() {
+            self.fmt_expr_block(body, true)?;
+        }
+        self.word(" catch ")?;
+        if let Some(param_list) = expr.catch_params() {
+            self.word("(")?;
+            self.cbox(1);
+            self.zerobreak();
+
+            let count = param_list.params().count();
+
+            for (i, param) in param_list.params().enumerate() {
+                if let Some(ident) = param.ident_token() {
+                    self.word(ident.static_text())?;
+                }
+                self.trailing_comma(i + 1 == count)?;
+            }
+
+            self.word(")")?;
+            self.space();
+            self.offset(-1);
+            self.end();
+            self.neverbreak();
+        }
+        if let Some(body) = expr.catch_block() {
+            self.fmt_expr_block(body, true)?;
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_import(
+        &mut self,
+        expr: rhai_rowan::ast::ExprImport,
+    ) -> Result<(), io::Error> {
+        self.word("import ")?;
+        if let Some(expr) = expr.expr() {
+            self.fmt_expr(expr)?;
+        }
+        if let Some(alias) = expr.alias() {
+            self.word(" as ")?;
+            self.word(alias.static_text())?;
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_export(
+        &mut self,
+        expr: rhai_rowan::ast::ExprExport,
+    ) -> Result<(), io::Error> {
+        self.word("export ")?;
+        if let Some(target) = expr.export_target() {
+            match target {
+                ExportTarget::ExprLet(expr) => self.fmt_expr_let(expr)?,
+                ExportTarget::ExprConst(expr) => self.fmt_expr_const(expr)?,
+                ExportTarget::Ident(ident) => {
+                    if let Some(ident) = ident.ident_token() {
+                        self.word(ident.static_text())?;
+                    }
+                }
+            }
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_fn(&mut self, expr: rhai_rowan::ast::ExprFn) -> Result<(), io::Error> {
+        if expr.kw_private_token().is_some() {
+            self.word("private ")?;
+        }
+        self.word("fn ")?;
+        if let Some(ident) = expr.ident_token() {
+            self.word(ident.static_text())?;
+        }
+        self.word("(")?;
+        self.cbox(1);
+        self.zerobreak();
+        if let Some(param_list) = expr.param_list() {
+            let count = param_list.params().count();
+
+            for (i, param) in param_list.params().enumerate() {
+                if let Some(ident) = param.ident_token() {
+                    self.word(ident.static_text())?;
+                }
+                self.trailing_comma(i + 1 == count)?;
+            }
+        }
+        self.word(")")?;
+        self.space();
+        self.offset(-1);
+        self.end();
+        self.neverbreak();
+        if let Some(body) = expr.body() {
+            self.fmt_expr_block(body, true)?;
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_return(
+        &mut self,
+        expr: rhai_rowan::ast::ExprReturn,
+    ) -> Result<(), io::Error> {
+        self.word("return")?;
+        if let Some(expr) = expr.expr() {
+            self.nbsp()?;
+            self.fmt_expr(expr)?;
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_switch(
+        &mut self,
+        expr: rhai_rowan::ast::ExprSwitch,
+    ) -> Result<(), io::Error> {
+        self.word("switch ")?;
+        if let Some(expr) = expr.expr() {
+            self.fmt_expr(expr)?;
+        }
+        self.nbsp()?;
+        self.word("{")?;
+        self.cbox(1);
+        self.hardbreak();
+        if let Some(arm_list) = expr.switch_arm_list() {
+            let arm_count = arm_list.arms().count();
+            for (i, arm) in arm_list.arms().enumerate() {
+                if i != 0 {
+                    self.hardbreak();
+                }
+
+                if let Some(pat) = arm.pattern_expr() {
+                    self.fmt_expr(pat)?;
+                }
+
+                if let Some(cond) = arm.condition().and_then(|c| c.expr()) {
+                    self.word(" if ")?;
+                    self.fmt_expr(cond)?;
+                }
+
+                self.word(" => ")?;
+
+                if let Some(expr) = arm.value_expr() {
+                    self.fmt_expr(expr)?;
+                }
+
+                let is_last = i + 1 == arm_count;
+                self.trailing_comma(is_last)?;
+            }
+        }
+        self.offset(-1);
+        self.end();
+        self.word("}")?;
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_continue(&mut self, _expr: ExprContinue) -> Result<(), io::Error> {
+        self.word("continue")?;
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_break(
+        &mut self,
+        expr: rhai_rowan::ast::ExprBreak,
+    ) -> Result<(), io::Error> {
+        self.word("break")?;
+        if let Some(expr) = expr.expr() {
+            self.nbsp()?;
+            self.fmt_expr(expr)?;
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_while(
+        &mut self,
+        expr: rhai_rowan::ast::ExprWhile,
+    ) -> Result<(), io::Error> {
+        self.cbox(0);
+        self.word("while ")?;
+        if let Some(cond) = expr.expr() {
+            self.fmt_expr(cond)?;
+        }
+        self.nbsp()?;
+        if let Some(body) = expr.loop_body() {
+            self.fmt_expr_block(body, true)?;
+        }
+        self.end();
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_loop(
+        &mut self,
+        expr: rhai_rowan::ast::ExprLoop,
+    ) -> Result<(), io::Error> {
+        self.word("loop ")?;
+        if let Some(expr) = expr.loop_body() {
+            self.fmt_expr_block(expr, false)?;
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_for(&mut self, expr: rhai_rowan::ast::ExprFor) -> Result<(), io::Error> {
+        self.word("for ")?;
+        if let Some(pat) = expr.pat() {
+            let ident_count = pat.idents().count();
+
+            if ident_count == 1 {
+                self.word(pat.idents().next().unwrap().static_text())?;
+            } else {
+                self.word("(")?;
+                self.cbox(1);
+                self.zerobreak();
+
+                for (i, ident) in pat.idents().enumerate() {
+                    self.word(ident.static_text())?;
+                    self.trailing_comma(i + 1 == ident_count)?;
+                }
+                self.offset(-1);
+                self.end();
+                self.word(")")?;
+            }
+
+            self.nbsp()?;
+        }
+        self.word("in ")?;
+        self.cbox(0);
+        if let Some(expr) = expr.iterable() {
+            self.fmt_expr(expr)?;
+        }
+        self.nbsp()?;
+        self.neverbreak();
+        if let Some(block) = expr.loop_body() {
+            self.fmt_expr_block(block, true)?;
+        }
+        self.end();
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_closure(
+        &mut self,
+        expr: rhai_rowan::ast::ExprClosure,
+    ) -> Result<(), io::Error> {
+        self.cbox(1);
+        self.word("|")?;
+        self.zerobreak();
+        if let Some(param_list) = expr.param_list() {
+            let count = param_list.params().count();
+
+            for (i, param) in param_list.params().enumerate() {
+                if let Some(ident) = param.ident_token() {
+                    self.word(ident.static_text())?;
+                }
+                self.trailing_comma(i + 1 == count)?;
+            }
+        }
+        self.word("|")?;
+        self.space();
+        self.offset(-1);
+        self.end();
+        self.neverbreak();
+        if let Some(body) = expr.body() {
+            self.fmt_expr(body)?;
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_call(
+        &mut self,
+        expr: rhai_rowan::ast::ExprCall,
+    ) -> Result<(), io::Error> {
+        if let Some(base) = expr.expr() {
+            self.fmt_expr(base)?;
+        }
+        self.word("(")?;
+        self.cbox(1);
+        self.zerobreak();
+        if let Some(args) = expr.arg_list() {
+            let count = args.arguments().count();
+
+            for (i, arg) in args.arguments().enumerate() {
+                self.fmt_expr(arg)?;
+                self.trailing_comma(i + 1 == count)?;
+            }
+        }
+        self.offset(-1);
+        self.end();
+        self.word(")")?;
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_object(
+        &mut self,
+        expr: rhai_rowan::ast::ExprObject,
+    ) -> Result<(), io::Error> {
+        let count = expr.fields().count();
+
+        if count == 0 {
+            return self.word("#{}");
+        }
+
+        let always_break = expr
+            .syntax()
+            .descendants_with_tokens()
+            .any(|c| match c.kind() {
+                COMMENT_LINE | COMMENT_LINE_DOC => true,
+                WHITESPACE => break_count(c.as_token().unwrap()) > 0,
+                _ => false,
+            });
+
+        self.word("#{")?;
+        self.cbox(1);
+
+        if always_break {
+            self.hardbreak();
+        } else {
+            self.space();
+        }
+
+        for (i, field) in expr.fields().enumerate() {
+            self.ibox(0);
+            if let Some(prop) = field.property() {
+                self.word(prop.static_text())?;
+            }
+
+            self.word(":")?;
+            self.space();
+            self.offset(1);
+            if let Some(expr) = field.expr() {
+                self.fmt_expr(expr)?;
+            }
+            self.end();
+
+            let last = i + 1 == count;
+
+            self.trailing_comma_or_space(last)?;
+        }
+        self.offset(-1);
+        self.end();
+        self.word("}")?;
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_index(
+        &mut self,
+        expr: rhai_rowan::ast::ExprIndex,
+    ) -> Result<(), io::Error> {
+        if let Some(base) = expr.base() {
+            self.fmt_expr(base)?;
+        }
+        self.word("[")?;
+        if let Some(idx) = expr.index() {
+            self.fmt_expr(idx)?;
+        }
+        self.word("]")?;
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_array(
+        &mut self,
+        expr: rhai_rowan::ast::ExprArray,
+    ) -> Result<(), io::Error> {
+        self.word("[")?;
+        self.cbox(1);
+        self.zerobreak();
+        let count = expr.values().count();
+        for (i, value) in expr.values().enumerate() {
+            self.fmt_expr(value)?;
+            self.trailing_comma(i + 1 == count)?;
+        }
+        self.offset(-1);
+        self.end();
+        self.word("]")?;
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_paren(
+        &mut self,
+        expr: rhai_rowan::ast::ExprParen,
+    ) -> Result<(), io::Error> {
+        self.word("(")?;
+        if let Some(expr) = expr.expr() {
+            self.fmt_expr(expr)?;
+        }
+        self.word(")")?;
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_binary(
+        &mut self,
+        expr: rhai_rowan::ast::ExprBinary,
+    ) -> Result<(), io::Error> {
+        self.ibox(1);
+        self.ibox(-1);
+        if let Some(lhs) = expr.lhs() {
+            self.fmt_expr(lhs)?;
+        }
+        self.end();
+        let space = expr
+            .op_token()
+            .map(|t| space_between(t.kind()))
+            .unwrap_or(false);
+        if space {
+            self.space();
+        }
+        if let Some(op) = expr.op_token() {
+            self.word(op.static_text())?;
+        }
+        if space {
+            self.nbsp()?;
+        }
+        if let Some(rhs) = expr.rhs() {
+            self.fmt_expr(rhs)?;
+        }
+        self.end();
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_unary(
+        &mut self,
+        expr: rhai_rowan::ast::ExprUnary,
+    ) -> Result<(), io::Error> {
+        if let Some(op) = expr.op_token() {
+            self.word(op.static_text())?;
+            if op.kind() == IDENT {
+                self.nbsp()?;
+            }
+        }
+        if let Some(expr) = expr.expr() {
+            self.fmt_expr(expr)?;
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_lit(&mut self, expr: rhai_rowan::ast::ExprLit) -> Result<(), io::Error> {
+        if let Some(lit) = expr.lit() {
+            if let Some(t) = lit
+                .lit_token()
+                .or_else(|| lit.lit_str_template().and_then(|t| t.lit_str_token()))
+            {
+                self.word(t.static_text())?;
+            }
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_path(
+        &mut self,
+        expr: rhai_rowan::ast::ExprPath,
+    ) -> Result<(), io::Error> {
+        if let Some(path) = expr.path() {
+            self.fmt_path(path)?;
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_ident(
+        &mut self,
+        expr: rhai_rowan::ast::ExprIdent,
+    ) -> Result<(), io::Error> {
+        if let Some(t) = expr.ident_token() {
+            self.word(t.static_text())?;
+        };
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_const(&mut self, expr: ExprConst) -> Result<(), io::Error> {
+        self.ibox(1);
+        self.word("const")?;
+        self.ibox(-1);
+        self.nbsp()?;
+        if let Some(ident) = expr.ident_token() {
+            self.word(ident.static_text())?;
+        }
+        self.end();
+        if let Some(rhs) = expr.expr() {
+            self.word(" = ")?;
+            self.fmt_expr(rhs)?;
+        }
+        self.end();
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_let(&mut self, expr: ExprLet) -> Result<(), io::Error> {
+        self.ibox(1);
+        self.word("let")?;
+        self.ibox(-1);
+        self.nbsp()?;
+        if let Some(ident) = expr.ident_token() {
+            self.word(ident.static_text())?;
+        }
+        self.end();
+        if let Some(rhs) = expr.expr() {
+            self.word(" = ")?;
+            self.fmt_expr(rhs)?;
+        }
+        self.end();
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_if(&mut self, expr: ExprIf) -> Result<(), io::Error> {
+        self.cbox(0);
+        self.word("if ")?;
+        self.cbox(0);
+        if let Some(cond) = expr.expr() {
+            self.fmt_expr(cond)?;
+        }
+        self.nbsp()?;
+        self.end();
+        if let Some(then) = expr.then_branch() {
+            self.fmt_expr_block(then, true)?;
+        }
+        self.end();
+
+        if let Some(else_if_branch) = expr.else_if_branch() {
+            self.word(" else ")?;
+            self.fmt_expr_if(else_if_branch)?;
+        }
+        self.cbox(0);
+        if let Some(else_branch) = expr.else_branch() {
+            self.word(" else ")?;
+            self.fmt_expr_block(else_branch, true)?;
+        }
+        self.end();
+
+        Ok(())
+    }
+
+    pub(crate) fn fmt_expr_block(
+        &mut self,
+        expr: ExprBlock,
+        mut always_break: bool,
+    ) -> io::Result<()> {
+        always_break = always_break
+            || expr
+                .syntax()
+                .descendants_with_tokens()
+                .any(|c| matches!(c.kind(), COMMENT_LINE | COMMENT_LINE_DOC));
+
+        let syntax = expr.syntax();
+
+        self.cbox(1);
+        self.word("{")?;
+        match expr.statements().count() {
+            0 => {
+                // Special case where the block
+                // contains comments but nothing else.
+                let comments = expr
+                    .syntax()
+                    .children_with_tokens()
+                    .filter_map(SyntaxElement::into_token)
+                    .filter(|t| matches!(t.kind(), COMMENT_BLOCK | COMMENT_LINE))
+                    .collect::<Vec<_>>();
+
+                if !comments.is_empty() {
+                    self.space();
+
+                    let mut first = true;
+                    for comment in comments {
+                        if !first {
+                            self.hardbreak();
+                        }
+                        first = false;
+                        self.word(comment.static_text().trim())?;
+                    }
+                    self.hardbreak();
+                    self.offset(-1);
+                }
+            }
+            1 => {
+                self.space();
+                self.leading_comments_in(&syntax)?;
+
+                let stmt = expr.statements().next().unwrap();
+
+                let had_sep = stmt
+                    .syntax()
+                    .children_with_tokens()
+                    .any(|c| c.kind() == T![";"]);
+
+                if let Some(item) = stmt.item() {
+                    let needs_sep = needs_stmt_separator(&item);
+                    self.fmt_item(item)?;
+
+                    if had_sep && needs_sep {
+                        self.word(";")?;
+                    }
+
+                    self.trailing_comments_after(&stmt.syntax(), true)?;
+                }
+
+                if always_break {
+                    self.hardbreak();
+                    self.offset(-1);
+                } else {
+                    self.space();
+                }
+            }
+            _ => {
+                self.space();
+                self.leading_comments_in(&syntax)?;
+
+                let count = expr.statements().count();
+
+                let mut first = true;
+                let mut needs_sep = false;
+                for (idx, stmt) in expr.statements().enumerate() {
+                    let item = match stmt.item() {
+                        Some(item) => item,
+                        _ => continue,
+                    };
+
+                    let syntax = stmt.syntax();
+
+                    if !first {
+                        if needs_sep {
+                            self.word(";")?;
+                        }
+
+                        self.comments_before_or_hardbreak(&syntax)?;
+                    }
+                    first = false;
+
+                    needs_sep = needs_stmt_separator(&item);
+                    self.fmt_item(item)?;
+
+                    let last = count == idx + 1;
+
+                    if last {
+                        let had_sep = stmt
+                            .syntax()
+                            .children_with_tokens()
+                            .any(|c| c.kind() == T![";"]);
+
+                        if had_sep && needs_sep {
+                            self.word(";")?;
+                        }
+
+                        self.trailing_comments_after(&syntax, false)?;
+                        self.hardbreak();
+                    }
+                }
+
+                self.offset(-1);
+            }
+        }
+        self.word("}")?;
+        self.end();
+        Ok(())
+    }
+}
+
+fn space_between(kind: SyntaxKind) -> bool {
+    match kind {
+        T![".."] | T!["..="] => false,
+        _ => true,
+    }
+}

--- a/crates/rhai-fmt/src/item.rs
+++ b/crates/rhai-fmt/src/item.rs
@@ -1,0 +1,39 @@
+use std::io::{self, Write};
+
+use rhai_rowan::ast::{AstNode, Item, Stmt};
+
+use crate::{algorithm::Formatter, util::ScopedStatic};
+
+impl<S: Write> Formatter<S> {
+    pub(crate) fn fmt_stmt(&mut self, stmt: Stmt) -> io::Result<()> {
+        if let Some(item) = stmt.item() {
+            self.fmt_item(item)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn fmt_item(&mut self, item: Item) -> io::Result<()> {
+        self.cbox(0);
+
+        for doc in item.docs() {
+            self.fmt_doc(doc)?;
+        }
+
+        if let Some(expr) = item.expr() {
+            self.fmt_expr(expr)?;
+        }
+
+        self.end();
+
+        Ok(())
+    }
+
+    pub(crate) fn fmt_doc(&mut self, doc: rhai_rowan::ast::Doc) -> Result<(), io::Error> {
+        if let Some(t) = doc.token() {
+            self.word(t.static_text().trim_end())?;
+            self.trailing_comments_after(&doc.syntax(), false)?;
+            self.hardbreak();
+        };
+        Ok(())
+    }
+}

--- a/crates/rhai-fmt/src/lib.rs
+++ b/crates/rhai-fmt/src/lib.rs
@@ -1,0 +1,65 @@
+// #![warn(clippy::pedantic)]
+#![allow(
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::derive_partial_eq_without_eq,
+    clippy::doc_markdown,
+    clippy::enum_glob_use,
+    clippy::items_after_statements,
+    clippy::match_like_matches_macro,
+    clippy::match_same_arms,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::needless_pass_by_value,
+    clippy::similar_names,
+    clippy::too_many_lines,
+    clippy::unused_self,
+    clippy::vec_init_then_push,
+    clippy::wildcard_imports,
+    clippy::cast_possible_truncation
+)]
+
+mod algorithm;
+mod cst;
+mod expr;
+mod item;
+mod options;
+mod path;
+mod ring;
+mod source;
+mod util;
+mod comments;
+
+pub use options::Options;
+use rhai_rowan::{parser::Parser, syntax::SyntaxElement};
+
+pub use algorithm::Formatter;
+
+#[must_use]
+#[allow(clippy::missing_panics_doc)]
+pub fn format_syntax(cst: impl Into<SyntaxElement>, options: Options) -> String {
+    let mut s = Vec::new();
+    Formatter::new_with_options(&mut s, options)
+        .format(cst)
+        .unwrap();
+    // SAFETY: we only print valid UTF-8.
+    unsafe { String::from_utf8_unchecked(s) }
+}
+
+#[must_use]
+#[allow(clippy::missing_panics_doc)]
+pub fn format_source(src: &str, options: Options) -> String {
+    let mut s = Vec::new();
+
+    let cst = if rhai_rowan::util::is_rhai_def(src) {
+        Parser::new(src).parse_def().into_syntax()
+    } else {
+        Parser::new(src).parse_script().into_syntax()
+    };
+
+    Formatter::new_with_options(&mut s, options)
+        .format(cst)
+        .unwrap();
+    // SAFETY: we only print valid UTF-8.
+    unsafe { String::from_utf8_unchecked(s) }
+}

--- a/crates/rhai-fmt/src/options.rs
+++ b/crates/rhai-fmt/src/options.rs
@@ -1,0 +1,36 @@
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Options {
+    pub crlf: bool,
+    pub max_empty_lines: u64,
+    pub max_width: u64,
+    #[serde(with = "serde_indent_str")]
+    pub indent_string: Arc<str>,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            crlf: false,
+            max_width: 80,
+            max_empty_lines: 2,
+            indent_string: Arc::from("  "),
+        }
+    }
+}
+
+mod serde_indent_str {
+    use super::*;
+
+    pub fn serialize<S: serde::ser::Serializer>(rc: &Arc<str>, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&**rc)
+    }
+
+    pub fn deserialize<'de, S: serde::de::Deserializer<'de>>(de: S) -> Result<Arc<str>, S::Error> {
+        let s = <&str>::deserialize(de)?;
+        Ok(Arc::from(s))
+    }
+}

--- a/crates/rhai-fmt/src/path.rs
+++ b/crates/rhai-fmt/src/path.rs
@@ -1,0 +1,20 @@
+use std::io::{self, Write};
+
+use rhai_rowan::ast::Path;
+
+use crate::{algorithm::Formatter, util::ScopedStatic};
+
+impl<S: Write> Formatter<S> {
+    pub(crate) fn fmt_path(&mut self, path: Path) -> io::Result<()> {
+        let mut first = true;
+        for segment in path.segments() {
+            if !first {
+                self.word("::")?;
+            }
+            first = false;
+
+            self.word(segment.static_text())?;
+        }
+        Ok(())
+    }
+}

--- a/crates/rhai-fmt/src/ring.rs
+++ b/crates/rhai-fmt/src/ring.rs
@@ -1,0 +1,81 @@
+use std::collections::VecDeque;
+use std::ops::{Index, IndexMut};
+
+pub struct RingBuffer<T> {
+    data: VecDeque<T>,
+    // Abstract index of data[0] in infinitely sized queue
+    offset: usize,
+}
+
+impl<T> RingBuffer<T> {
+    pub fn new() -> Self {
+        RingBuffer {
+            data: VecDeque::new(),
+            offset: 0,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn push(&mut self, value: T) -> usize {
+        let index = self.offset + self.data.len();
+        self.data.push_back(value);
+        index
+    }
+
+    pub fn clear(&mut self) {
+        self.data.clear();
+    }
+
+    pub fn index_of_first(&self) -> usize {
+        self.offset
+    }
+
+    pub fn first(&self) -> &T {
+        &self.data[0]
+    }
+
+    pub fn first_mut(&mut self) -> &mut T {
+        &mut self.data[0]
+    }
+
+    pub fn pop_first(&mut self) -> T {
+        self.offset += 1;
+        self.data.pop_front().unwrap()
+    }
+
+    pub fn last(&self) -> &T {
+        self.data.back().unwrap()
+    }
+
+    pub fn last_mut(&mut self) -> &mut T {
+        self.data.back_mut().unwrap()
+    }
+
+    pub fn second_last(&self) -> &T {
+        &self.data[self.data.len() - 2]
+    }
+
+    pub fn pop_last(&mut self) {
+        self.data.pop_back().unwrap();
+    }
+}
+
+impl<T> Index<usize> for RingBuffer<T> {
+    type Output = T;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.data[index.checked_sub(self.offset).unwrap()]
+    }
+}
+
+impl<T> IndexMut<usize> for RingBuffer<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.data[index.checked_sub(self.offset).unwrap()]
+    }
+}

--- a/crates/rhai-fmt/src/source.rs
+++ b/crates/rhai-fmt/src/source.rs
@@ -1,0 +1,79 @@
+use std::io::{self, Write};
+
+use rhai_rowan::{
+    ast::{AstNode, Item, Rhai},
+    syntax::SyntaxKind::*,
+    T,
+};
+
+use crate::{algorithm::Formatter, util::ScopedStatic};
+
+impl<S: Write> Formatter<S> {
+    pub(crate) fn fmt_rhai(&mut self, rhai: Rhai) -> io::Result<()> {
+        self.cbox(0);
+
+        if let Some(t) = rhai.shebang_token() {
+            self.word(t.static_text())?;
+            self.hardbreak();
+        }
+
+        self.leading_comments_in(&rhai.syntax())?;
+
+        let count = rhai.statements().count();
+
+        let mut first = true;
+        let mut needs_sep = false;
+        for (idx, stmt) in rhai.statements().enumerate() {
+            let item = match stmt.item() {
+                Some(item) => item,
+                _ => continue,
+            };
+            let syntax = stmt.syntax();
+
+            if !first {
+                if needs_sep {
+                    self.word(";")?;
+                }
+
+                self.comments_before_or_hardbreak(&syntax)?;
+            }
+            first = false;
+
+            needs_sep = needs_stmt_separator(&item);
+            self.fmt_item(item)?;
+
+            let last = count == idx + 1;
+
+            if last {
+                let had_sep = stmt
+                    .syntax()
+                    .children_with_tokens()
+                    .any(|c| c.kind() == T![";"]);
+
+                if had_sep && needs_sep {
+                    self.word(";")?;
+                }
+                self.trailing_comments_after(&syntax, false)?;
+                self.hardbreak();
+            }
+        }
+
+        self.end();
+
+        Ok(())
+    }
+}
+
+pub(crate) fn needs_stmt_separator(item: &Item) -> bool {
+    match item
+        .expr()
+        .and_then(|e| e.syntax().first_child())
+        .map(|e| e.kind())
+    {
+        Some(
+            EXPR_IDENT | EXPR_BLOCK | EXPR_IF | EXPR_LOOP | EXPR_FOR | EXPR_WHILE | EXPR_SWITCH
+            | EXPR_FN | EXPR_TRY,
+        ) => false,
+        _ => true,
+    }
+}

--- a/crates/rhai-fmt/src/util.rs
+++ b/crates/rhai-fmt/src/util.rs
@@ -1,0 +1,158 @@
+#![allow(dead_code)]
+use rhai_rowan::syntax::{SyntaxKind::*, SyntaxNode, SyntaxToken};
+use rowan::Direction;
+
+use crate::algorithm::{self, BeginToken, BreakToken, Breaks, Formatter};
+use std::{
+    io::{self, Write},
+    mem,
+};
+
+impl<W: Write> Formatter<W> {
+    pub(crate) fn ibox(&mut self, indent: isize) {
+        self.scan_begin(BeginToken {
+            offset: indent,
+            breaks: Breaks::Inconsistent,
+        });
+    }
+
+    pub(crate) fn cbox(&mut self, indent: isize) {
+        self.scan_begin(BeginToken {
+            offset: indent,
+            breaks: Breaks::Consistent,
+        });
+    }
+
+    pub(crate) fn end(&mut self) {
+        self.scan_end();
+    }
+
+    pub(crate) fn word(&mut self, wrd: &'static str) -> io::Result<()> {
+        self.scan_string(wrd)
+    }
+
+    fn spaces(&mut self, n: usize) {
+        self.scan_break(BreakToken {
+            blank_space: n,
+            ..BreakToken::default()
+        });
+    }
+
+    pub(crate) fn zerobreak(&mut self) {
+        self.spaces(0);
+    }
+
+    pub(crate) fn space(&mut self) {
+        self.spaces(1);
+    }
+
+    pub(crate) fn nbsp(&mut self) -> io::Result<()> {
+        self.word(" ")
+    }
+
+    pub(crate) fn hardbreak(&mut self) {
+        self.spaces(algorithm::SIZE_INFINITY as usize);
+    }
+
+    pub(crate) fn hardbreaks(&mut self, count: u64) {
+        for _ in 0..count.min(self.options.max_empty_lines + 1) {
+            self.spaces(algorithm::SIZE_INFINITY as usize);
+        }
+    }
+
+    pub(crate) fn space_if_nonempty(&mut self) {
+        self.scan_break(BreakToken {
+            blank_space: 1,
+            if_nonempty: true,
+            ..BreakToken::default()
+        });
+    }
+
+    pub(crate) fn hardbreak_if_nonempty(&mut self) {
+        self.scan_break(BreakToken {
+            blank_space: algorithm::SIZE_INFINITY as usize,
+            if_nonempty: true,
+            ..BreakToken::default()
+        });
+    }
+
+    pub(crate) fn trailing_comma(&mut self, is_last: bool) -> io::Result<()> {
+        if is_last {
+            self.scan_break(BreakToken {
+                pre_break: Some(','),
+                ..BreakToken::default()
+            });
+        } else {
+            self.word(",")?;
+            self.space();
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn trailing_comma_or_space(&mut self, is_last: bool) -> io::Result<()> {
+        if is_last {
+            self.scan_break(BreakToken {
+                blank_space: 1,
+                pre_break: Some(','),
+                ..BreakToken::default()
+            });
+        } else {
+            self.word(",")?;
+            self.space();
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn neverbreak(&mut self) {
+        self.scan_break(BreakToken {
+            never_break: true,
+            ..BreakToken::default()
+        });
+    }
+}
+
+pub(crate) trait ScopedStatic {
+    fn static_text(&self) -> &'static str;
+}
+
+impl ScopedStatic for SyntaxToken {
+    fn static_text(&self) -> &'static str {
+        // SAFETY: we guarantee that the syntax token
+        // outlives the formatting process.
+        unsafe { mem::transmute(self.text()) }
+    }
+}
+
+pub(crate) fn breaks_before(node: &SyntaxNode) -> u64 {
+    if let Some(elem) = node.siblings_with_tokens(Direction::Prev).nth(1) {
+        if let Some(t) = elem.into_token() {
+            if t.kind() == WHITESPACE {
+                return break_count(&t);
+            }
+        }
+    }
+
+    0
+}
+
+pub(crate) fn break_count(t: &SyntaxToken) -> u64 {
+    t.text().chars().filter(|c| *c == '\n').count() as u64
+}
+
+#[test]
+fn lol() {
+    let src = r#"
+#{
+    a: 2,
+
+    b: 3,
+}"#;
+
+    let node = rhai_rowan::parser::Parser::new(src)
+        .parse_script()
+        .into_syntax();
+
+    println!("{node:#?}");
+}

--- a/crates/rhai-fmt/tests/fmt.rs
+++ b/crates/rhai-fmt/tests/fmt.rs
@@ -1,0 +1,27 @@
+use pretty_assertions::assert_eq;
+
+macro_rules! assert_fmt {
+    ($src:expr) => {
+        {
+            let s = $src;
+            assert_eq!(s, rhai_fmt::format_source(s, Default::default()));
+        }
+    };
+    ($src:expr, $expected:expr) => {
+        {
+            let s = $src;
+            assert_eq!($expected, rhai_fmt::format_source(s));
+        }
+    };
+}
+
+#[test]
+fn fmt_smoke() {
+    let _ = tracing_subscriber::fmt().with_max_level(tracing::Level::DEBUG).try_init();
+
+    assert_fmt!("/// hello
+/// there
+let a = 1234;
+let b = 'a'
+");
+}

--- a/crates/rhai-lsp/Cargo.toml
+++ b/crates/rhai-lsp/Cargo.toml
@@ -33,3 +33,4 @@ tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 url = "2.2.2"
 rhai-common = { version = "0.1.0", path = "../rhai-common" }
 tokio = { version = "1.20.1", features = ["sync"] }
+rhai-fmt = { version = "0.1.0", path = "../rhai-fmt" }

--- a/crates/rhai-lsp/src/handlers.rs
+++ b/crates/rhai-lsp/src/handlers.rs
@@ -45,3 +45,6 @@ pub(crate) use semantic_tokens::*;
 
 mod debug;
 pub(crate) use debug::*;
+
+mod formatting;
+pub(crate) use formatting::*;

--- a/crates/rhai-lsp/src/handlers/completion.rs
+++ b/crates/rhai-lsp/src/handlers/completion.rs
@@ -21,6 +21,7 @@ use rhai_hir::{
 };
 use rhai_rowan::{query::Query, TextRange};
 
+#[tracing::instrument(skip_all)]
 pub(crate) async fn completion<E: Environment>(
     context: Context<World<E>>,
     params: Params<CompletionParams>,

--- a/crates/rhai-lsp/src/handlers/convert_offsets.rs
+++ b/crates/rhai-lsp/src/handlers/convert_offsets.rs
@@ -6,6 +6,7 @@ use crate::{
     world::World,
 };
 
+#[tracing::instrument(skip_all)]
 pub(crate) async fn convert_offsets<E: Environment>(
     context: Context<World<E>>,
     params: Params<ConvertOffsetsParams>,

--- a/crates/rhai-lsp/src/handlers/debug.rs
+++ b/crates/rhai-lsp/src/handlers/debug.rs
@@ -6,6 +6,7 @@ use lsp_async_stub::{rpc, Context, Params};
 use rhai_common::environment::Environment;
 use rhai_hir::fmt::HirFmt;
 
+#[tracing::instrument(skip_all)]
 pub(crate) async fn hir_dump<E: Environment>(
     context: Context<World<E>>,
     params: Params<HirDumpParams>,

--- a/crates/rhai-lsp/src/handlers/document_symbols.rs
+++ b/crates/rhai-lsp/src/handlers/document_symbols.rs
@@ -14,6 +14,7 @@ use rhai_rowan::{
     syntax::{SyntaxElement, SyntaxKind, SyntaxNode},
 };
 
+#[tracing::instrument(skip_all)]
 pub(crate) async fn document_symbols<E: Environment>(
     context: Context<World<E>>,
     params: Params<DocumentSymbolParams>,

--- a/crates/rhai-lsp/src/handlers/folding_ranges.rs
+++ b/crates/rhai-lsp/src/handlers/folding_ranges.rs
@@ -10,6 +10,7 @@ use lsp_async_stub::{
 use lsp_types::{FoldingRange, FoldingRangeKind, FoldingRangeParams, Range};
 use rhai_rowan::syntax::{SyntaxElement, SyntaxKind::*, SyntaxNode};
 
+#[tracing::instrument(skip_all)]
 pub(crate) async fn folding_ranges<E: Environment>(
     context: Context<World<E>>,
     params: Params<FoldingRangeParams>,

--- a/crates/rhai-lsp/src/handlers/formatting.rs
+++ b/crates/rhai-lsp/src/handlers/formatting.rs
@@ -1,0 +1,38 @@
+use std::sync::Arc;
+
+use crate::world::World;
+use lsp_async_stub::{rpc, util::LspExt, Context, Params};
+use lsp_types::{DocumentFormattingParams, TextEdit};
+use rhai_common::environment::Environment;
+
+#[tracing::instrument(skip_all)]
+pub(crate) async fn format<E: Environment>(
+    context: Context<World<E>>,
+    params: Params<DocumentFormattingParams>,
+) -> Result<Option<Vec<TextEdit>>, rpc::Error> {
+    let p = params.required()?;
+
+    let workspaces = context.workspaces.read().await;
+    let ws = workspaces.by_document(&p.text_document.uri);
+    let doc = match ws.document(&p.text_document.uri) {
+        Ok(d) => d,
+        Err(error) => {
+            tracing::debug!(%error, "failed to get document from workspace");
+            return Ok(None);
+        }
+    };
+
+    let format_opts = rhai_fmt::Options {
+        indent_string: if p.options.insert_spaces {
+            Arc::from(" ".repeat(p.options.tab_size as usize).as_str())
+        } else {
+            "\t".into()
+        },
+        ..Default::default()
+    };
+
+    Ok(Some(vec![TextEdit {
+        range: doc.mapper.all_range().into_lsp(),
+        new_text: rhai_fmt::format_syntax(doc.parse.clone_syntax(), format_opts),
+    }]))
+}

--- a/crates/rhai-lsp/src/handlers/goto.rs
+++ b/crates/rhai-lsp/src/handlers/goto.rs
@@ -8,6 +8,7 @@ use lsp_types::{
 };
 use rhai_hir::symbol::ReferenceTarget;
 
+#[tracing::instrument(skip_all)]
 pub(crate) async fn goto_declaration<E: Environment>(
     context: Context<World<E>>,
     params: Params<GotoDeclarationParams>,

--- a/crates/rhai-lsp/src/handlers/initialize.rs
+++ b/crates/rhai-lsp/src/handlers/initialize.rs
@@ -62,6 +62,7 @@ pub async fn initialize<E: Environment>(
             definition_provider: Some(OneOf::Left(true)),
             document_symbol_provider: Some(OneOf::Left(true)),
             hover_provider: Some(HoverProviderCapability::Simple(true)),
+            document_formatting_provider: Some(OneOf::Left(true)),
             semantic_tokens_provider: Some(
                 SemanticTokensServerCapabilities::SemanticTokensOptions(SemanticTokensOptions {
                     work_done_progress_options: WorkDoneProgressOptions {

--- a/crates/rhai-lsp/src/handlers/references.rs
+++ b/crates/rhai-lsp/src/handlers/references.rs
@@ -7,6 +7,7 @@ use lsp_types::{Location, ReferenceParams};
 use rhai_hir::Symbol;
 use rhai_rowan::{syntax::SyntaxKind, TextRange, TextSize};
 
+#[tracing::instrument(skip_all)]
 pub(crate) async fn references<E: Environment>(
     context: Context<World<E>>,
     params: Params<ReferenceParams>,

--- a/crates/rhai-lsp/src/lib.rs
+++ b/crates/rhai-lsp/src/lib.rs
@@ -41,6 +41,7 @@ pub fn create_server<E: Environment>() -> Server<World<E>> {
         .on_request::<request::Completion, _>(handlers::completion)
         .on_request::<request::PrepareRenameRequest, _>(handlers::prepare_rename)
         .on_request::<request::Rename, _>(handlers::rename)
+        .on_request::<request::Formatting, _>(handlers::format)
         .on_notification::<notification::Initialized, _>(handlers::initialized)
         .on_notification::<notification::DidOpenTextDocument, _>(handlers::document_open)
         .on_notification::<notification::DidChangeTextDocument, _>(handlers::document_change)

--- a/crates/rhai-rowan/Cargo.toml
+++ b/crates/rhai-rowan/Cargo.toml
@@ -12,7 +12,7 @@ rowan = { version = "0.15.5", features = ["serde1"] }
 thiserror = "1.0.29"
 tracing = { version = "0.1.28" }
 serde = { version = "1", features = ["derive"] }
-strum = "0.24.1"
+strum = { version = "0.24.1", features = ["derive"] }
 
 [dev-dependencies]
 insta = "1.8.0"

--- a/crates/rhai-rowan/src/ast/ext.rs
+++ b/crates/rhai-rowan/src/ast/ext.rs
@@ -66,18 +66,6 @@ impl super::ExprLet {
     }
 }
 
-impl super::ExprReturn {
-    pub fn expr(&self) -> Option<Expr> {
-        self.syntax().children().find_map(Expr::cast)
-    }
-}
-
-impl super::ExprBreak {
-    pub fn expr(&self) -> Option<Expr> {
-        self.syntax().children().find_map(Expr::cast)
-    }
-}
-
 impl super::Stmt {
     pub fn item(&self) -> Option<super::Item> {
         self.syntax().children().find_map(super::Item::cast)
@@ -114,18 +102,6 @@ impl super::Path {
                     && t.kind() != SyntaxKind::COMMENT_LINE
             })
             .filter_map(SyntaxElement::into_token)
-    }
-}
-
-impl super::ExprFn {
-    #[must_use]
-    pub fn kw_private_token(&self) -> Option<SyntaxToken> {
-        self.syntax().children_with_tokens().find_map(|t| {
-            if t.kind() != SyntaxKind::KW_PRIVATE {
-                return None;
-            }
-            t.into_token()
-        })
     }
 }
 

--- a/crates/rhai-rowan/src/ast/rhai.ungram
+++ b/crates/rhai-rowan/src/ast/rhai.ungram
@@ -156,7 +156,7 @@ SwitchArmList =
   '{' arms:(SwitchArm (',' SwitchArm)* ','?)? '}'
 
 SwitchArm =
-  pattern:(Expr | '_') condition:SwitchArmCondition? '=>' Expr
+  pattern:(Expr | '_') condition:SwitchArmCondition? '=>' __expr:Expr
 
 SwitchArmCondition =
   'if' Expr

--- a/crates/rhai-sourcegen/src/syntax/mod.rs
+++ b/crates/rhai-sourcegen/src/syntax/mod.rs
@@ -271,7 +271,7 @@ fn generate_ast(grammar: &Grammar) -> String {
                     };
 
                     let rule = match inner_rule {
-                        Rule::Labeled { label: _, rule } => rule,
+                        Rule::Labeled { label: _, rule } | Rule::Opt(rule) => rule,
                         r => r,
                     };
 


### PR DESCRIPTION
I rely heavily on formatters during development and with the LSP finally taking shape it really bothered me that we don't have one. I only focused on Rhai itself, so types and definitions are not formatted.

I repurposed [prettyplease](https://github.com/dtolnay/prettyplease)'s core and implemented formatting on top of the rowan-based CST. Most of the algorithm is unchanged, the main change is the ability to print to a stream directly and I also made it more configurable (e.g. prettyplease was not designed for indentation with tabs).

Things went pretty smoothly until I started implementing comments, they are all over the place and aren't in the AST so special fiddling is required. Funnily enough after a while I just gave up a perfect implementation and decided to only include comments where they make sense only to realize that rustfmt does pretty much the same.

I think this implementation will do for now, it's satisfactory for me and we can always polish it later.

Closes #10.