### PR TITLE
fix compile errors

### DIFF
--- a/crates/rhai-common/Cargo.toml
+++ b/crates/rhai-common/Cargo.toml
@@ -33,4 +33,4 @@ glob = "0.3.0"
 atty = "0.2.14"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tokio = { version = "1.19.2" }
+tokio = { version = "1.19.2", features = ["io-util"]}

--- a/crates/rhai-lsp/Cargo.toml
+++ b/crates/rhai-lsp/Cargo.toml
@@ -22,7 +22,7 @@ glob = "0.3.0"
 globset = "0.4.9"
 indexmap = "1.9.1"
 itertools = "0.10.3"
-lsp-async-stub = { version = "0.6.0", features = ["tokio-stdio"] }
+lsp-async-stub = "0.6.0"
 lsp-types = "0.93.0"
 once_cell = "1.12.0"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/editors/vscode/src/server.ts
+++ b/editors/vscode/src/server.ts
@@ -31,6 +31,7 @@ process.on("message", async (d: RpcMessage) => {
         glob: p => glob.sync(p),
         isAbsolute: p => path.isAbsolute(p),
         readFile: path => fsPromise.readFile(path),
+        writeFile: (path, data) => fsPromise.writeFile(path, data),
         stderr: process.stderr,
         stdErrAtty: () => process.stderr.isTTY,
         stdin: process.stdin,

--- a/js/core/src/environment.ts
+++ b/js/core/src/environment.ts
@@ -37,6 +37,10 @@ export interface Environment {
    */
   readFile: (path: string) => Promise<Uint8Array>;
   /**
+   * Write a file at the given path.
+   */
+  writeFile: (path: string, data: Uint8Array) => Promise<void>;
+  /**
    * Search a glob file pattern and return the matched files.
    */
   glob: (pattern: string) => Array<string>;
@@ -93,6 +97,7 @@ export function convertEnv(env: Environment): any {
     js_url_to_file_path: env.urlToFilePath,
     js_sleep: env.sleep,
     js_read_file: env.readFile,
+    js_write_file: env.writeFile,
   };
 }
 


### PR DESCRIPTION
Fixed several bugs preventing rhai-wasm from compiling:
  1. Removed the redundant feature of lsp-async-stub
  2. Fixed AsyncWriteExt import
  3. Implemented the write_file function required by the Environment for WasmEnvironment with reference to read_file (**Not tested, I'm not sure if it works correctly**)