### PR TITLE
remove deprecated serde option in wasm-bindgen

### DIFF
--- a/crates/rhai-wasm/Cargo.toml
+++ b/crates/rhai-wasm/Cargo.toml
@@ -19,6 +19,7 @@ console_error_panic_hook = "0.1.7"
 futures = "0.3.21"
 js-sys = "0.3.57"
 serde = { version = "1.0.137", features = ["derive"] }
+serde-wasm-bindgen = "0.5.0"
 serde_json = "1.0.81"
 tokio = "1.19.2"
 tracing = "0.1.35"

--- a/crates/rhai-wasm/src/environment.rs
+++ b/crates/rhai-wasm/src/environment.rs
@@ -297,7 +297,7 @@ impl Environment for WasmEnvironment {
             .js_glob_files
             .call1(&this, &JsValue::from_str(glob))
             .unwrap();
-        res.into_serde().map_err(|err| anyhow!("{err}"))
+        serde_wasm_bindgen::from_value(res).map_err(|err| anyhow!("{err}"))
     }
 
     async fn read_file(&self, path: &Path) -> Result<Vec<u8>, anyhow::Error> {

--- a/crates/rhai-wasm/src/lsp.rs
+++ b/crates/rhai-wasm/src/lsp.rs
@@ -17,7 +17,7 @@ pub struct RhaiWasmLsp {
 #[wasm_bindgen]
 impl RhaiWasmLsp {
     pub fn send(&self, message: JsValue) -> Result<(), JsError> {
-        let message: lsp_async_stub::rpc::Message = message.into_serde()?;
+        let message: lsp_async_stub::rpc::Message = serde_wasm_bindgen::from_value(message)?;
         let world = self.world.clone();
         let writer = self.lsp_interface.clone();
 
@@ -64,7 +64,7 @@ impl Sink<rpc::Message> for WasmLspInterface {
     ) -> Result<(), Self::Error> {
         let this = JsValue::null();
         self.js_on_message
-            .call1(&this, &JsValue::from_serde(&message).unwrap())
+            .call1(&this, &serde_wasm_bindgen::to_value(&message).unwrap())
             .unwrap();
         Ok(())
     }


### PR DESCRIPTION
`JsValue::from_serde` and `JsValue::into_serde` are deprecated
see https://github.com/rustwasm/wasm-bindgen/pull/3031